### PR TITLE
feat: port test_cannot_run_js to CTS

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -49,7 +49,7 @@ Tests covering the engine-specific part of Node-API, defined in `js_native_api.h
 | `8_passing_wrapped`          | Ported ✅  | Easy       |
 | `test_array`                 | Ported ✅  | Easy       |
 | `test_bigint`                | Ported ✅  | Easy       |
-| `test_cannot_run_js`         | Not ported | Medium     |
+| `test_cannot_run_js`         | Ported ✅  | Medium     |
 | `test_constructor`           | Ported ✅  | Medium     |
 | `test_conversions`           | Ported ✅  | Medium     |
 | `test_dataview`              | Not ported | Medium     |

--- a/tests/js-native-api/test_cannot_run_js/CMakeLists.txt
+++ b/tests/js-native-api/test_cannot_run_js/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_node_api_cts_addon(test_cannot_run_js test_cannot_run_js.c)
+target_compile_definitions(test_cannot_run_js PRIVATE NAPI_VERSION=10)
+
+add_node_api_cts_addon(test_pending_exception test_cannot_run_js.c)
+target_compile_definitions(test_pending_exception PRIVATE NAPI_VERSION=9)

--- a/tests/js-native-api/test_cannot_run_js/test.js
+++ b/tests/js-native-api/test_cannot_run_js/test.js
@@ -1,0 +1,21 @@
+// Test that `napi_get_named_property()` returns `napi_cannot_run_js` in
+// experimental mode and `napi_pending_exception` otherwise. This test calls
+// the add-on's `createRef()` method, which creates a strong reference to a JS
+// function. When the process exits, it calls all reference finalizers. The
+// finalizer for the strong reference created herein will attempt to call
+// `napi_get_property()` on a property of the global object and will abort the
+// process if the API doesn't return the correct status.
+
+const addon_v8 = loadAddon('test_pending_exception');
+const addon_new = loadAddon('test_cannot_run_js');
+
+function runTests(addon) {
+  addon.createRef(function() { throw new Error('function should not have been called'); });
+}
+
+function runAllTests() {
+  runTests(addon_v8);
+  runTests(addon_new);
+}
+
+runAllTests();

--- a/tests/js-native-api/test_cannot_run_js/test.js
+++ b/tests/js-native-api/test_cannot_run_js/test.js
@@ -6,11 +6,14 @@
 // `napi_get_property()` on a property of the global object and will abort the
 // process if the API doesn't return the correct status.
 
-const addon_v8 = loadAddon('test_pending_exception');
-const addon_new = loadAddon('test_cannot_run_js');
+if (napiVersion < 10) skipTest();
+const addon_v8 = loadAddon("test_pending_exception");
+const addon_new = loadAddon("test_cannot_run_js");
 
 function runTests(addon) {
-  addon.createRef(function() { throw new Error('function should not have been called'); });
+  addon.createRef(function () {
+    throw new Error("function should not have been called");
+  });
 }
 
 function runAllTests() {

--- a/tests/js-native-api/test_cannot_run_js/test_cannot_run_js.c
+++ b/tests/js-native-api/test_cannot_run_js/test_cannot_run_js.c
@@ -1,0 +1,66 @@
+#include <js_native_api.h>
+#include "../common.h"
+#include "../entry_point.h"
+#include "stdlib.h"
+
+static void Finalize(napi_env env, void* data, void* hint) {
+  napi_value global, set_timeout;
+  napi_ref* ref = data;
+
+  NODE_API_BASIC_ASSERT_RETURN_VOID(
+      napi_delete_reference(env, *ref) == napi_ok,
+      "deleting reference in finalizer should succeed");
+  NODE_API_BASIC_ASSERT_RETURN_VOID(
+      napi_get_global(env, &global) == napi_ok,
+      "getting global reference in finalizer should succeed");
+  napi_status result =
+      napi_get_named_property(env, global, "setTimeout", &set_timeout);
+
+  // The finalizer could be invoked either from check callbacks (as native
+  // immediates) if the event loop is still running (where napi_ok is returned)
+  // or during environment shutdown (where napi_cannot_run_js or
+  // napi_pending_exception is returned). This is not deterministic from
+  // the point of view of the addon.
+
+#if NAPI_VERSION > 9
+  NODE_API_BASIC_ASSERT_RETURN_VOID(
+      result == napi_cannot_run_js || result == napi_ok,
+      "getting named property from global in finalizer should succeed "
+      "or return napi_cannot_run_js");
+#else
+  NODE_API_BASIC_ASSERT_RETURN_VOID(
+      result == napi_pending_exception || result == napi_ok,
+      "getting named property from global in finalizer should succeed "
+      "or return napi_pending_exception");
+#endif  // NAPI_VERSION > 9
+  free(ref);
+}
+
+static napi_value CreateRef(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value cb;
+  napi_valuetype value_type;
+  napi_ref* ref = malloc(sizeof(*ref));
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, &cb, NULL, NULL));
+  NODE_API_ASSERT(env, argc == 1, "Function takes only one argument");
+  NODE_API_CALL(env, napi_typeof(env, cb, &value_type));
+  NODE_API_ASSERT(
+      env, value_type == napi_function, "argument must be function");
+  NODE_API_CALL(env, napi_add_finalizer(env, cb, ref, Finalize, NULL, ref));
+  return cb;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+      DECLARE_NODE_API_PROPERTY("createRef", CreateRef),
+  };
+
+  NODE_API_CALL(
+      env,
+      napi_define_properties(
+          env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+EXTERN_C_END


### PR DESCRIPTION
## Summary

Ports `test_cannot_run_js` from `node/test/js-native-api/` to the CTS.

- Builds two addons from the same C source (`test_cannot_run_js` with `NAPI_VERSION=10`, `test_pending_exception` with `NAPI_VERSION=9`) to cover both code paths in the finalizer
- Verifies that when a finalizer tries to access JS during environment shutdown, `napi_get_named_property` returns `napi_cannot_run_js` (v10+), `napi_pending_exception` (v9), or `napi_ok` if the event loop is still running

Upstream source: https://github.com/nodejs/node/tree/main/test/js-native-api/test_cannot_run_js

## Test plan

- [x] `npm run addons:configure && npm run addons:build` — both addons compile cleanly
- [x] `npm run node:test` — all 56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)