### PR TITLE
feat: port test_dataview to CTS

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -52,7 +52,7 @@ Tests covering the engine-specific part of Node-API, defined in `js_native_api.h
 | `test_cannot_run_js`         | Not ported | Medium     |
 | `test_constructor`           | Ported ✅  | Medium     |
 | `test_conversions`           | Ported ✅  | Medium     |
-| `test_dataview`              | Not ported | Medium     |
+| `test_dataview`              | Ported ✅  | Medium     |
 | `test_date`                  | Ported ✅  | Easy       |
 | `test_error`                 | Ported ✅  | Medium     |
 | `test_exception`             | Not ported | Medium     |

--- a/implementors/node/features.js
+++ b/implementors/node/features.js
@@ -2,7 +2,7 @@
 // Each key corresponds to a NODE_API_EXPERIMENTAL_HAS_* compile-time macro.
 // Other implementors should set unsupported features to false or omit them.
 
-const [major, minor] = process.version.slice(1).split('.').map(Number);
+const [major, minor, patch] = process.version.slice(1).split(".").map(Number);
 
 globalThis.experimentalFeatures = {
   // node_api_is_sharedarraybuffer and node_api_create_sharedarraybuffer were
@@ -12,4 +12,11 @@ globalThis.experimentalFeatures = {
   createObjectWithProperties: true,
   setPrototype: true,
   postFinalizer: true,
+  // napi_create_dataview accepts a SharedArrayBuffer-backed buffer only since
+  // Node.js v24.13.1 and v25.4.0 (nodejs/node#60473). It was not backported to
+  // v20.x or v22.x, where such calls fail with "invalid argument".
+  dataviewSharedArrayBuffer:
+    major > 25 ||
+    (major === 25 && minor >= 4) ||
+    (major === 24 && (minor > 13 || (minor === 13 && patch >= 1))),
 };

--- a/tests/js-native-api/test_dataview/CMakeLists.txt
+++ b/tests/js-native-api/test_dataview/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_node_api_cts_experimental_addon(test_dataview test_dataview.c)

--- a/tests/js-native-api/test_dataview/CMakeLists.txt
+++ b/tests/js-native-api/test_dataview/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_node_api_cts_experimental_addon(test_dataview test_dataview.c)
+add_node_api_cts_addon(test_dataview test_dataview.c)

--- a/tests/js-native-api/test_dataview/test.js
+++ b/tests/js-native-api/test_dataview/test.js
@@ -1,48 +1,46 @@
 "use strict";
 
-if (experimentalFeatures.sharedArrayBuffer) {
-  // Testing api calls for arrays
-  const test_dataview = loadAddon("test_dataview");
+// Testing api calls for dataview
+const test_dataview = loadAddon("test_dataview");
 
-  // Test for creating dataview with ArrayBuffer
-  {
-    const buffer = new ArrayBuffer(128);
-    const template = Reflect.construct(DataView, [buffer]);
+// Test for creating dataview with ArrayBuffer
+{
+  const buffer = new ArrayBuffer(128);
+  const template = Reflect.construct(DataView, [buffer]);
 
-    const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
-    assert.ok(
-      theDataview instanceof DataView,
-      `Expect ${theDataview} to be a DataView`,
-    );
-  }
+  const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
+  assert.ok(
+    theDataview instanceof DataView,
+    `Expect ${theDataview} to be a DataView`,
+  );
+}
 
-  // Test for creating dataview with SharedArrayBuffer
-  {
-    const buffer = new SharedArrayBuffer(128);
-    const template = new DataView(buffer);
+// Test for creating dataview with SharedArrayBuffer
+{
+  const buffer = new SharedArrayBuffer(128);
+  const template = new DataView(buffer);
 
-    const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
-    assert.ok(
-      theDataview instanceof DataView,
-      `Expect ${theDataview} to be a DataView`,
-    );
+  const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
+  assert.ok(
+    theDataview instanceof DataView,
+    `Expect ${theDataview} to be a DataView`,
+  );
 
-    assert.strictEqual(template.buffer, theDataview.buffer);
-  }
+  assert.strictEqual(template.buffer, theDataview.buffer);
+}
 
-  // Test for creating dataview with ArrayBuffer and invalid range
-  {
-    const buffer = new ArrayBuffer(128);
-    assert.throws(() => {
-      test_dataview.CreateDataView(buffer, 10, 200);
-    }, RangeError);
-  }
+// Test for creating dataview with ArrayBuffer and invalid range
+{
+  const buffer = new ArrayBuffer(128);
+  assert.throws(() => {
+    test_dataview.CreateDataView(buffer, 10, 200);
+  }, RangeError);
+}
 
-  // Test for creating dataview with SharedArrayBuffer and invalid range
-  {
-    const buffer = new SharedArrayBuffer(128);
-    assert.throws(() => {
-      test_dataview.CreateDataView(buffer, 10, 200);
-    }, RangeError);
-  }
+// Test for creating dataview with SharedArrayBuffer and invalid range
+{
+  const buffer = new SharedArrayBuffer(128);
+  assert.throws(() => {
+    test_dataview.CreateDataView(buffer, 10, 200);
+  }, RangeError);
 }

--- a/tests/js-native-api/test_dataview/test.js
+++ b/tests/js-native-api/test_dataview/test.js
@@ -15,31 +15,9 @@ const test_dataview = loadAddon("test_dataview");
   );
 }
 
-// Test for creating dataview with SharedArrayBuffer
-{
-  const buffer = new SharedArrayBuffer(128);
-  const template = new DataView(buffer);
-
-  const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
-  assert.ok(
-    theDataview instanceof DataView,
-    `Expect ${theDataview} to be a DataView`,
-  );
-
-  assert.strictEqual(template.buffer, theDataview.buffer);
-}
-
 // Test for creating dataview with ArrayBuffer and invalid range
 {
   const buffer = new ArrayBuffer(128);
-  assert.throws(() => {
-    test_dataview.CreateDataView(buffer, 10, 200);
-  }, RangeError);
-}
-
-// Test for creating dataview with SharedArrayBuffer and invalid range
-{
-  const buffer = new SharedArrayBuffer(128);
   assert.throws(() => {
     test_dataview.CreateDataView(buffer, 10, 200);
   }, RangeError);

--- a/tests/js-native-api/test_dataview/test.js
+++ b/tests/js-native-api/test_dataview/test.js
@@ -1,0 +1,48 @@
+"use strict";
+
+if (experimentalFeatures.sharedArrayBuffer) {
+  // Testing api calls for arrays
+  const test_dataview = loadAddon("test_dataview");
+
+  // Test for creating dataview with ArrayBuffer
+  {
+    const buffer = new ArrayBuffer(128);
+    const template = Reflect.construct(DataView, [buffer]);
+
+    const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
+    assert.ok(
+      theDataview instanceof DataView,
+      `Expect ${theDataview} to be a DataView`,
+    );
+  }
+
+  // Test for creating dataview with SharedArrayBuffer
+  {
+    const buffer = new SharedArrayBuffer(128);
+    const template = new DataView(buffer);
+
+    const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
+    assert.ok(
+      theDataview instanceof DataView,
+      `Expect ${theDataview} to be a DataView`,
+    );
+
+    assert.strictEqual(template.buffer, theDataview.buffer);
+  }
+
+  // Test for creating dataview with ArrayBuffer and invalid range
+  {
+    const buffer = new ArrayBuffer(128);
+    assert.throws(() => {
+      test_dataview.CreateDataView(buffer, 10, 200);
+    }, RangeError);
+  }
+
+  // Test for creating dataview with SharedArrayBuffer and invalid range
+  {
+    const buffer = new SharedArrayBuffer(128);
+    assert.throws(() => {
+      test_dataview.CreateDataView(buffer, 10, 200);
+    }, RangeError);
+  }
+}

--- a/tests/js-native-api/test_dataview/test_dataview.c
+++ b/tests/js-native-api/test_dataview/test_dataview.c
@@ -1,0 +1,111 @@
+#include <js_native_api.h>
+#include <string.h>
+#include "../common.h"
+#include "../entry_point.h"
+
+static napi_value CreateDataView(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value args [3];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NODE_API_ASSERT(env, argc == 3, "Wrong number of arguments");
+
+  napi_valuetype valuetype0;
+  napi_value arraybuffer = args[0];
+
+  NODE_API_CALL(env, napi_typeof(env, arraybuffer, &valuetype0));
+  NODE_API_ASSERT(env, valuetype0 == napi_object,
+              "Wrong type of arguments. Expects a ArrayBuffer as the first "
+              "argument.");
+
+  bool is_arraybuffer;
+  NODE_API_CALL(env, napi_is_arraybuffer(env, arraybuffer, &is_arraybuffer));
+
+  if (!is_arraybuffer) {
+    bool is_sharedarraybuffer;
+    NODE_API_CALL(
+        env,
+        node_api_is_sharedarraybuffer(env, arraybuffer, &is_sharedarraybuffer));
+    NODE_API_ASSERT(env,
+                    is_sharedarraybuffer,
+                    "Wrong type of arguments. Expects a SharedArrayBuffer or "
+                    "ArrayBuffer as the first "
+                    "argument.");
+  }
+
+  napi_valuetype valuetype1;
+  NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
+
+  NODE_API_ASSERT(env, valuetype1 == napi_number,
+      "Wrong type of arguments. Expects a number as second argument.");
+
+  size_t byte_offset = 0;
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[1], (uint32_t*)(&byte_offset)));
+
+  napi_valuetype valuetype2;
+  NODE_API_CALL(env, napi_typeof(env, args[2], &valuetype2));
+
+  NODE_API_ASSERT(env, valuetype2 == napi_number,
+      "Wrong type of arguments. Expects a number as third argument.");
+
+  size_t length = 0;
+  NODE_API_CALL(env, napi_get_value_uint32(env, args[2], (uint32_t*)(&length)));
+
+  napi_value output_dataview;
+  NODE_API_CALL(env,
+            napi_create_dataview(env, length, arraybuffer,
+                                 byte_offset, &output_dataview));
+
+  return output_dataview;
+}
+
+static napi_value CreateDataViewFromJSDataView(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args [1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NODE_API_ASSERT(env, argc == 1, "Wrong number of arguments");
+
+  napi_valuetype valuetype;
+  napi_value input_dataview = args[0];
+
+  NODE_API_CALL(env, napi_typeof(env, input_dataview, &valuetype));
+  NODE_API_ASSERT(env, valuetype == napi_object,
+              "Wrong type of arguments. Expects a DataView as the first "
+              "argument.");
+
+  bool is_dataview;
+  NODE_API_CALL(env, napi_is_dataview(env, input_dataview, &is_dataview));
+  NODE_API_ASSERT(env, is_dataview,
+              "Wrong type of arguments. Expects a DataView as the first "
+              "argument.");
+  size_t byte_offset = 0;
+  size_t length = 0;
+  napi_value buffer;
+  NODE_API_CALL(env,
+            napi_get_dataview_info(env, input_dataview, &length, NULL,
+                                   &buffer, &byte_offset));
+
+  napi_value output_dataview;
+  NODE_API_CALL(env,
+            napi_create_dataview(env, length, buffer,
+                                 byte_offset, &output_dataview));
+
+
+  return output_dataview;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor descriptors[] = {
+    DECLARE_NODE_API_PROPERTY("CreateDataView", CreateDataView),
+    DECLARE_NODE_API_PROPERTY("CreateDataViewFromJSDataView",
+        CreateDataViewFromJSDataView)
+  };
+
+  NODE_API_CALL(env, napi_define_properties(
+      env, exports, sizeof(descriptors) / sizeof(*descriptors), descriptors));
+
+  return exports;
+}
+EXTERN_C_END

--- a/tests/js-native-api/test_dataview/test_dataview.c
+++ b/tests/js-native-api/test_dataview/test_dataview.c
@@ -18,21 +18,6 @@ static napi_value CreateDataView(napi_env env, napi_callback_info info) {
               "Wrong type of arguments. Expects a ArrayBuffer as the first "
               "argument.");
 
-  bool is_arraybuffer;
-  NODE_API_CALL(env, napi_is_arraybuffer(env, arraybuffer, &is_arraybuffer));
-
-  if (!is_arraybuffer) {
-    bool is_sharedarraybuffer;
-    NODE_API_CALL(
-        env,
-        node_api_is_sharedarraybuffer(env, arraybuffer, &is_sharedarraybuffer));
-    NODE_API_ASSERT(env,
-                    is_sharedarraybuffer,
-                    "Wrong type of arguments. Expects a SharedArrayBuffer or "
-                    "ArrayBuffer as the first "
-                    "argument.");
-  }
-
   napi_valuetype valuetype1;
   NODE_API_CALL(env, napi_typeof(env, args[1], &valuetype1));
 

--- a/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
+++ b/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// napi_create_dataview accepts a SharedArrayBuffer-backed buffer only on newer
+// Node.js releases (see implementors/node/features.js).
+if (!experimentalFeatures.dataviewSharedArrayBuffer) {
+  skipTest();
+}
+
+// Testing api calls for dataview backed by a SharedArrayBuffer
+const test_dataview = loadAddon("test_dataview");
+
+// Test for creating dataview with SharedArrayBuffer
+{
+  const buffer = new SharedArrayBuffer(128);
+  const template = new DataView(buffer);
+
+  const theDataview = test_dataview.CreateDataViewFromJSDataView(template);
+  assert.ok(
+    theDataview instanceof DataView,
+    `Expect ${theDataview} to be a DataView`,
+  );
+
+  assert.strictEqual(template.buffer, theDataview.buffer);
+}
+
+// Test for creating dataview with SharedArrayBuffer and invalid range
+{
+  const buffer = new SharedArrayBuffer(128);
+  assert.throws(() => {
+    test_dataview.CreateDataView(buffer, 10, 200);
+  }, RangeError);
+}


### PR DESCRIPTION
Ports
[https://github.com/nodejs/node/tree/main/test/js-native-api/test_dataview](test_dataview) from Node.js test suite to the CTS.
This test contains an experimental feature `SharedArrayBuffer`, resulting in usage of `add_node_api_cts_experimental_addon()`.

<!--
Before submitting a pull request, please read
https://github.com/nodejs/node-api-cts/blob/main/CONTRIBUTING.md.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
