### PR TITLE
feat: flattern tests allowing --test-name-pattern filter

### DIFF
--- a/implementors/node/README.md
+++ b/implementors/node/README.md
@@ -1,0 +1,27 @@
+# Harness of Node.js
+
+## Build addons
+
+To build the addons, run the following command:
+
+```bash
+$ npm run addons:configure
+$ npm run addons:build
+```
+
+## Running tests
+
+Run the following command to run the tests:
+
+```bash
+$ npm run node:test
+```
+
+To run a specific test file, use the `--test-name-pattern` flag:
+
+```bash
+$ NODE_OPTIONS=--test-name-pattern=js-native-api/test_constructor/test_null npm run node:test
+```
+
+The test names are their relative path to the `tests` folder, with file extensions.
+The pattern can be a regular expression.

--- a/implementors/node/run-tests.ts
+++ b/implementors/node/run-tests.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { test, type TestContext } from "node:test";
+import { test } from "node:test";
 
 import { listDirectoryEntries, runFileInSubprocess } from "./tests.ts";
 
@@ -19,31 +19,21 @@ const LOAD_ADDON_MODULE_PATH = path.join(
   "load-addon.js"
 );
 
-async function populateSuite(
-  testContext: TestContext,
+
+function populateSuite(
   dir: string
-): Promise<void> {
+) {
   const { directories, files } = listDirectoryEntries(dir);
 
   for (const file of files) {
-    await testContext.test(file, () => runFileInSubprocess(dir, file));
+    test(path.relative(TESTS_ROOT_PATH, path.join(dir, file)), () => runFileInSubprocess(dir, file));
   }
 
   for (const directory of directories) {
-    await testContext.test(directory, async (subTest) => {
-      await populateSuite(subTest, path.join(dir, directory));
-    });
+    populateSuite(path.join(dir, directory));
   }
 }
 
-test("harness", async (t) => {
-  await populateSuite(t, path.join(TESTS_ROOT_PATH, "harness"));
-});
-
-test("js-native-api", async (t) => {
-  await populateSuite(t, path.join(TESTS_ROOT_PATH, "js-native-api"));
-});
-
-test("node-api", async (t) => {
-  await populateSuite(t, path.join(TESTS_ROOT_PATH, "node-api"));
-});
+populateSuite(path.join(TESTS_ROOT_PATH, "harness"));
+populateSuite(path.join(TESTS_ROOT_PATH, "js-native-api"));
+populateSuite(path.join(TESTS_ROOT_PATH, "node-api"));


### PR DESCRIPTION
Allow filtering tests with the node test runner `--test-name-pattern` flag.