### PR TITLE
chore: add tsconfig.json restricting `erasableSyntaxOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "node:test": "node --test ./implementors/node/run-tests.ts",
-    "lint": "eslint && tsc -p .",
+    "lint": "eslint && tsc",
     "addons:configure": "cmake -S . -B ./build",
     "addons:build": "cmake --build ./build",
     "addons:clean": "git clean -xf '**/*.node' && rm -rf ./build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "node:test": "node --test ./implementors/node/run-tests.ts",
-    "lint": "eslint",
+    "lint": "eslint && tsc -p .",
     "addons:configure": "cmake -S . -B ./build",
     "addons:build": "cmake --build ./build",
     "addons:clean": "git clean -xf '**/*.node' && rm -rf ./build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "rootDir": "./",
+    "noEmit": true,
+
+    "types": ["node"],
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+  },
+  "exclude": [
+    "**/CMakeFiles/**"
+  ]
+}


### PR DESCRIPTION
Restricts TypeScript syntax to be `erasableSyntaxOnly` and perform type-checks in CI.