### PR TITLE
chore: extract skipTest into its own harness module

### DIFF
--- a/implementors/node/features.js
+++ b/implementors/node/features.js
@@ -9,7 +9,3 @@ globalThis.experimentalFeatures = {
 };
 
 globalThis.napiVersion = Number(process.versions.napi);
-
-globalThis.skipTest = () => {
-  process.exit(0);
-};

--- a/implementors/node/skip-test.js
+++ b/implementors/node/skip-test.js
@@ -1,0 +1,3 @@
+globalThis.skipTest = () => {
+  process.exit(0);
+};

--- a/implementors/node/tests.ts
+++ b/implementors/node/tests.ts
@@ -40,6 +40,12 @@ const MUST_CALL_MODULE_PATH = path.join(
   "node",
   "must-call.js"
 );
+const SKIP_TEST_MODULE_PATH = path.join(
+  ROOT_PATH,
+  "implementors",
+  "node",
+  "skip-test.js"
+);
 
 export function listDirectoryEntries(dir: string) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -80,6 +86,8 @@ export function runFileInSubprocess(
         "file://" + GC_MODULE_PATH,
         "--import",
         "file://" + MUST_CALL_MODULE_PATH,
+        "--import",
+        "file://" + SKIP_TEST_MODULE_PATH,
         filePath,
       ],
       { cwd }

--- a/tests/harness/skip-test.js
+++ b/tests/harness/skip-test.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// skipTest is a function
+if (typeof skipTest !== 'function') {
+  throw new Error('Expected a global skipTest function');
+}


### PR DESCRIPTION
Let's follow a pattern of separating harness utilities into separate files and have a test for each to make it easier for implementors to implement the harness.

## Summary
- Moved `skipTest` from `implementors/node/features.js` into a dedicated `implementors/node/skip-test.js`, matching the pattern of other harness utilities (assert, must-call, gc, load-addon)
- Added `--import` for the new module in `implementors/node/tests.ts`
- Added `tests/harness/skip-test.js` to verify the `skipTest` global is available as a function

## Test plan
- [x] All harness tests pass (7/7), including the new `skip-test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)