### PR TITLE
chore: extract napiVersion into its own harness module

### DIFF
--- a/implementors/node/features.js
+++ b/implementors/node/features.js
@@ -8,8 +8,6 @@ globalThis.experimentalFeatures = {
   postFinalizer: true,
 };
 
-globalThis.napiVersion = Number(process.versions.napi);
-
 globalThis.skipTest = () => {
   process.exit(0);
 };

--- a/implementors/node/napi-version.js
+++ b/implementors/node/napi-version.js
@@ -1,0 +1,1 @@
+globalThis.napiVersion = Number(process.versions.napi);

--- a/implementors/node/tests.ts
+++ b/implementors/node/tests.ts
@@ -40,6 +40,12 @@ const MUST_CALL_MODULE_PATH = path.join(
   "node",
   "must-call.js"
 );
+const NAPI_VERSION_MODULE_PATH = path.join(
+  ROOT_PATH,
+  "implementors",
+  "node",
+  "napi-version.js"
+);
 
 export function listDirectoryEntries(dir: string) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -80,6 +86,8 @@ export function runFileInSubprocess(
         "file://" + GC_MODULE_PATH,
         "--import",
         "file://" + MUST_CALL_MODULE_PATH,
+        "--import",
+        "file://" + NAPI_VERSION_MODULE_PATH,
         filePath,
       ],
       { cwd }

--- a/tests/harness/napi-version.js
+++ b/tests/harness/napi-version.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// napiVersion is a positive integer
+if (typeof napiVersion !== 'number' || napiVersion < 1 || !Number.isInteger(napiVersion)) {
+  throw new Error('Expected a global napiVersion that is a positive integer');
+}


### PR DESCRIPTION
Following the pattern from #56, separate `napiVersion` from `implementors/node/features.js` into a dedicated module and add a harness test for it.

## Summary
- Moved `napiVersion` from `implementors/node/features.js` into a dedicated `implementors/node/napi-version.js`
- Added `--import` for the new module in `implementors/node/tests.ts`
- Added `tests/harness/napi-version.js` to verify the `napiVersion` global is a positive integer

## Test plan
- [x] All harness tests pass (6/6), including the new `napi-version.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)