### PR TITLE
refactor: use suite/test for hierarchical test structure

### DIFF
--- a/implementors/node/README.md
+++ b/implementors/node/README.md
@@ -17,11 +17,12 @@ Run the following command to run the tests:
 $ npm run node:test
 ```
 
-To run a specific test file, use the `--test-name-pattern` flag:
+To run a specific test suite or file, use the `--test-name-pattern` flag:
 
 ```bash
-$ NODE_OPTIONS=--test-name-pattern=js-native-api/test_constructor/test_null npm run node:test
+$ NODE_OPTIONS=--test-name-pattern=test_constructor npm run node:test
 ```
 
-The test names are their relative path to the `tests` folder, with file extensions.
+The pattern matches against suite names (directory names) and test names (file names)
+at any level of the hierarchy. When a suite matches, all tests inside it run.
 The pattern can be a regular expression.

--- a/implementors/node/run-tests.ts
+++ b/implementors/node/run-tests.ts
@@ -1,25 +1,33 @@
 import path from "node:path";
-import { test } from "node:test";
+import { suite, test } from "node:test";
 
 import { listDirectoryEntries, runFileInSubprocess } from "./tests.ts";
 
 const ROOT_PATH = path.resolve(import.meta.dirname, "..", "..");
 const TESTS_ROOT_PATH = path.join(ROOT_PATH, "tests");
 
-function populateSuite(
-  dir: string
-) {
+function populateSuite(dir: string) {
   const { directories, files } = listDirectoryEntries(dir);
 
   for (const file of files) {
-    test(path.relative(TESTS_ROOT_PATH, path.join(dir, file)), () => runFileInSubprocess(dir, file));
+    test(file, () => runFileInSubprocess(dir, file));
   }
 
   for (const directory of directories) {
-    populateSuite(path.join(dir, directory));
+    suite(directory, () => {
+      populateSuite(path.join(dir, directory));
+    });
   }
 }
 
-populateSuite(path.join(TESTS_ROOT_PATH, "harness"));
-populateSuite(path.join(TESTS_ROOT_PATH, "js-native-api"));
-populateSuite(path.join(TESTS_ROOT_PATH, "node-api"));
+suite("harness", () => {
+  populateSuite(path.join(TESTS_ROOT_PATH, "harness"));
+});
+
+suite("js-native-api", () => {
+  populateSuite(path.join(TESTS_ROOT_PATH, "js-native-api"));
+});
+
+suite("node-api", () => {
+  populateSuite(path.join(TESTS_ROOT_PATH, "node-api"));
+});


### PR DESCRIPTION
This is mainly an alternative suggestion to #50 - feel free to close.

## Summary
- Replaces the flat `test()` calls (from #50) with `suite()`/`test()` nesting, restoring hierarchical test output while keeping `--test-name-pattern` filtering support
- `--test-name-pattern` matches against both suite names (directories) and test names (files), so filtering works at any level of the hierarchy
- Updates README example to show the simpler suite-level filtering

## Motivation

PR #50 flattened all tests into top-level `test()` calls with path-like names (e.g. `js-native-api/test_string/test.js`) to enable `--test-name-pattern` filtering. This works but comes with trade-offs:

- **Lost hierarchical output**: all tests appear at the same indentation level, making it harder to visually scan results by category
- **Lost suite-level timing**: with nesting, the test runner reports aggregate duration per suite (e.g. how long all `test_string` tests took combined), which is lost when tests are flat

Using `suite()`/`test()` nesting preserves all of these while still supporting `--test-name-pattern` — the Node.js test runner matches the pattern against suite names too, running all tests inside a matching suite.

## Test plan
- [x] `npm run node:test` passes (all tests run with hierarchical output)
- [x] `NODE_OPTIONS=--test-name-pattern=test_constructor npm run node:test` correctly filters to only tests in the `test_constructor` suite
- [x] `NODE_OPTIONS=--test-name-pattern=test_null npm run node:test` correctly filters leaf tests across suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>