### PR TITLE
refactor: move dataviewSharedArrayBuffer gate out of experimentalFeatures

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,6 +102,7 @@ export default defineConfig([
         gc: 'readonly',
         gcUntil: 'readonly',
         experimentalFeatures: 'readonly',
+        runtimeFeatures: 'readonly',
         onUncaughtException: 'readonly',
         napiVersion: 'readonly',
         skipTest: 'readonly',

--- a/implementors/node/features.js
+++ b/implementors/node/features.js
@@ -1,9 +1,10 @@
-// Declares which experimental Node-API features this runtime supports.
-// Each key corresponds to a NODE_API_EXPERIMENTAL_HAS_* compile-time macro.
+// Declares which Node-API features this runtime supports, for tests to gate on.
 // Other implementors should set unsupported features to false or omit them.
 
 const [major, minor, patch] = process.version.slice(1).split('.').map(Number);
 
+// Experimental features behind the NAPI_EXPERIMENTAL define. Each key
+// corresponds to a NODE_API_EXPERIMENTAL_HAS_* compile-time macro.
 globalThis.experimentalFeatures = {
   // node_api_is_sharedarraybuffer and node_api_create_sharedarraybuffer were
   // added in Node.js v24.9.0. Earlier versions do not export these symbols,
@@ -12,6 +13,10 @@ globalThis.experimentalFeatures = {
   createObjectWithProperties: true,
   setPrototype: true,
   postFinalizer: true,
+};
+
+// Version-dependent behaviors of stable (non-experimental) Node-API.
+globalThis.runtimeFeatures = {
   // napi_create_dataview accepts a SharedArrayBuffer-backed buffer only since
   // Node.js v24.13.1 and v25.4.0 (nodejs/node#60473). It was not backported to
   // v20.x or v22.x, where such calls fail with "invalid argument".

--- a/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
+++ b/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
@@ -2,7 +2,7 @@
 
 // napi_create_dataview accepts a SharedArrayBuffer-backed buffer only on newer
 // Node.js releases (see implementors/node/features.js).
-if (!experimentalFeatures.dataviewSharedArrayBuffer) {
+if (!runtimeFeatures.dataviewSharedArrayBuffer) {
   skipTest();
 }
 


### PR DESCRIPTION
Follow-up to #39.

`napi_create_dataview` is a stable (non-experimental) Node-API. Its SharedArrayBuffer support is version-dependent — it landed in Node.js v24.13.1 and v25.4.0 (nodejs/node#60473) — but that is a runtime-version behavior, not a feature behind `NAPI_EXPERIMENTAL`. So the gate did not belong in `experimentalFeatures`.

This moves the `dataviewSharedArrayBuffer` flag into a new `runtimeFeatures` global for version-dependent behaviors of stable APIs. The version math stays in the Node harness; tests (and other implementors) just read a boolean, keeping test files runtime-agnostic.

- `implementors/node/features.js` — add `runtimeFeatures`, move the flag out of `experimentalFeatures`
- `eslint.config.js` — allow `runtimeFeatures` in test files
- `tests/js-native-api/test_dataview/test_sharedarraybuffer.js` — gate on `runtimeFeatures.dataviewSharedArrayBuffer`