### PR TITLE
chore: enforce code formatting with @stylistic, mirroring nodejs/node

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,15 +1,93 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import globals from "globals";
+import { defineConfig, globalIgnores } from 'eslint/config';
+import globals from 'globals';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import stylistic from '@stylistic/eslint-plugin';
 
 export default defineConfig([
-  globalIgnores(["**/CMakeFiles/**"]),
+  globalIgnores(['**/CMakeFiles/**', 'build/**']),
   eslint.configs.recommended,
   tseslint.configs.recommended,
+  // Formatting rules mirrored from nodejs/node's eslint.config.mjs.
+  // nodejs/node uses the JS-only @stylistic/eslint-plugin-js; this repo has
+  // TypeScript, so we use the unified @stylistic/eslint-plugin (same rules,
+  // JS + TS aware). Keep this block in sync with upstream when it changes.
+  {
+    files: ['**/*.{js,mjs,ts}'],
+    plugins: { '@stylistic': stylistic },
+    rules: {
+      '@stylistic/arrow-parens': 'error',
+      '@stylistic/arrow-spacing': 'error',
+      '@stylistic/block-spacing': 'error',
+      '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: true }],
+      '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/comma-spacing': 'error',
+      '@stylistic/comma-style': 'error',
+      '@stylistic/computed-property-spacing': 'error',
+      '@stylistic/dot-location': ['error', 'property'],
+      '@stylistic/eol-last': 'error',
+      '@stylistic/function-call-spacing': 'error',
+      '@stylistic/indent': ['error', 2, {
+        ArrayExpression: 'first',
+        CallExpression: { arguments: 'first' },
+        FunctionDeclaration: { parameters: 'first' },
+        FunctionExpression: { parameters: 'first' },
+        MemberExpression: 'off',
+        ObjectExpression: 'first',
+        SwitchCase: 1,
+        assignmentOperator: 'off',
+      }],
+      '@stylistic/key-spacing': 'error',
+      '@stylistic/keyword-spacing': 'error',
+      '@stylistic/linebreak-style': 'error',
+      '@stylistic/max-len': ['error', {
+        code: 120,
+        ignorePattern: '^// Flags:',
+        ignoreRegExpLiterals: true,
+        ignoreTemplateLiterals: true,
+        ignoreUrls: true,
+        tabWidth: 2,
+      }],
+      '@stylistic/new-parens': 'error',
+      '@stylistic/no-confusing-arrow': 'error',
+      '@stylistic/no-extra-parens': ['error', 'functions'],
+      '@stylistic/no-multi-spaces': ['error', { ignoreEOLComments: true }],
+      '@stylistic/no-multiple-empty-lines': ['error', { max: 2, maxEOF: 0, maxBOF: 0 }],
+      '@stylistic/no-tabs': 'error',
+      '@stylistic/no-trailing-spaces': 'error',
+      '@stylistic/no-whitespace-before-property': 'error',
+      '@stylistic/object-curly-newline': 'error',
+      '@stylistic/object-curly-spacing': ['error', 'always'],
+      '@stylistic/one-var-declaration-per-line': 'error',
+      '@stylistic/operator-linebreak': ['error', 'after'],
+      '@stylistic/padding-line-between-statements': [
+        'error',
+        { blankLine: 'always', prev: 'function', next: 'function' },
+      ],
+      '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: 'always' }],
+      '@stylistic/quote-props': ['error', 'consistent'],
+      '@stylistic/rest-spread-spacing': 'error',
+      '@stylistic/semi': 'error',
+      '@stylistic/semi-spacing': 'error',
+      '@stylistic/space-before-blocks': ['error', 'always'],
+      '@stylistic/space-before-function-paren': ['error', {
+        anonymous: 'never',
+        named: 'never',
+        asyncArrow: 'always',
+      }],
+      '@stylistic/space-in-parens': 'error',
+      '@stylistic/space-infix-ops': 'error',
+      '@stylistic/space-unary-ops': 'error',
+      '@stylistic/spaced-comment': ['error', 'always', {
+        block: { balanced: true },
+        exceptions: ['-'],
+      }],
+      '@stylistic/template-curly-spacing': 'error',
+    },
+  },
   {
     files: [
-      "tests/**/*.js",
+      'tests/**/*.js',
     ],
     languageOptions: {
       // Only allow ECMAScript built-ins and CTS harness globals.
@@ -17,32 +95,40 @@ export default defineConfig([
       globals: {
         ...globals.es2025,
         // CTS harness globals
-        assert: "readonly",
-        loadAddon: "readonly",
-        mustCall: "readonly",
-        mustNotCall: "readonly",
-        gc: "readonly",
-        gcUntil: "readonly",
-        experimentalFeatures: "readonly",
-        napiVersion: "readonly",
-        skipTest: "readonly",
+        assert: 'readonly',
+        loadAddon: 'readonly',
+        mustCall: 'readonly',
+        mustNotCall: 'readonly',
+        gc: 'readonly',
+        gcUntil: 'readonly',
+        experimentalFeatures: 'readonly',
+        onUncaughtException: 'readonly',
+        napiVersion: 'readonly',
+        skipTest: 'readonly',
       },
     },
     rules: {
-      "no-undef": "error",
-      "no-restricted-imports": ["error", {
-        patterns: ["*"],
+      'no-undef': 'error',
+      'no-restricted-imports': ['error', {
+        patterns: ['*'],
       }],
-      "no-restricted-syntax": ["error",
-        { selector: "MemberExpression[object.name='globalThis']", message: "Avoid globalThis access in test files — use CTS harness globals instead" },
-        { selector: "MemberExpression[object.name='global']", message: "Avoid global access in test files — use CTS harness globals instead" }
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "MemberExpression[object.name='globalThis']",
+          message: 'Avoid globalThis access in test files — use CTS harness globals instead',
+        },
+        {
+          selector: "MemberExpression[object.name='global']",
+          message: 'Avoid global access in test files — use CTS harness globals instead',
+        },
       ],
     },
   },
   {
     files: [
-      "implementors/**/*.{js,ts}",
-      "scripts/**/*.{js,mjs}",
+      'implementors/**/*.{js,ts}',
+      'scripts/**/*.{js,mjs}',
     ],
     languageOptions: {
       globals: {

--- a/implementors/node/assert.js
+++ b/implementors/node/assert.js
@@ -5,7 +5,7 @@ import {
   deepStrictEqual,
   throws,
   match,
-} from "node:assert/strict";
+} from 'node:assert/strict';
 
 const assert = Object.assign((value, message) => ok(value, message), {
   ok: (value, message) => ok(value, message),

--- a/implementors/node/features.js
+++ b/implementors/node/features.js
@@ -2,7 +2,7 @@
 // Each key corresponds to a NODE_API_EXPERIMENTAL_HAS_* compile-time macro.
 // Other implementors should set unsupported features to false or omit them.
 
-const [major, minor, patch] = process.version.slice(1).split(".").map(Number);
+const [major, minor, patch] = process.version.slice(1).split('.').map(Number);
 
 globalThis.experimentalFeatures = {
   // node_api_is_sharedarraybuffer and node_api_create_sharedarraybuffer were

--- a/implementors/node/gc.js
+++ b/implementors/node/gc.js
@@ -1,9 +1,9 @@
 // Capture the engine-provided gc (Node exposes it under --expose-gc) before
 // we overwrite globalThis.gc with the harness wrapper below.
 const engineGc = globalThis.gc;
-if (typeof engineGc !== "function") {
+if (typeof engineGc !== 'function') {
   throw new Error(
-    "Node harness expects globalThis.gc to be available (run with --expose-gc)",
+    'Node harness expects globalThis.gc to be available (run with --expose-gc)',
   );
 }
 

--- a/implementors/node/load-addon.js
+++ b/implementors/node/load-addon.js
@@ -1,13 +1,13 @@
-import assert from "node:assert/strict";
-import { dlopen } from "node:process";
-import { constants } from "node:os";
-import path from "node:path";
-import fs from "node:fs";
+import assert from 'node:assert/strict';
+import { dlopen } from 'node:process';
+import { constants } from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
 
 const loadAddon = (addonFileName) => {
-  assert(typeof addonFileName === "string", "Expected a string as addon filename");
-  assert(!addonFileName.endsWith(".node"), "Expected addon filename without the .node extension");
-  const addonPath = path.join(process.cwd(), addonFileName + ".node");
+  assert(typeof addonFileName === 'string', 'Expected a string as addon filename');
+  assert(!addonFileName.endsWith('.node'), 'Expected addon filename without the .node extension');
+  const addonPath = path.join(process.cwd(), addonFileName + '.node');
   assert(fs.existsSync(addonPath), `Expected ${addonPath} to exist - did you build the addons?`);
   const addon = { exports: {} };
   dlopen(addon, addonPath, constants.dlopen.RTLD_NOW);

--- a/implementors/node/must-call.js
+++ b/implementors/node/must-call.js
@@ -13,7 +13,7 @@ const mustCall = (fn, exact = 1) => {
   const entry = {
     exact,
     actual: 0,
-    name: fn?.name || "<anonymous>",
+    name: fn?.name || '<anonymous>',
     error: new Error(), // capture call-site stack
   };
   pendingCalls.push(entry);
@@ -28,11 +28,11 @@ const mustCall = (fn, exact = 1) => {
  */
 const mustNotCall = (msg) => {
   return () => {
-    throw new Error(msg || "mustNotCall function was called");
+    throw new Error(msg || 'mustNotCall function was called');
   };
 };
 
-process.on("exit", () => {
+process.on('exit', () => {
   for (const entry of pendingCalls) {
     if (entry.actual !== entry.exact) {
       entry.error.message =

--- a/implementors/node/run-tests.ts
+++ b/implementors/node/run-tests.ts
@@ -1,13 +1,13 @@
-import path from "node:path";
-import { test } from "node:test";
+import path from 'node:path';
+import { test } from 'node:test';
 
-import { listDirectoryEntries, runFileInSubprocess } from "./tests.ts";
+import { listDirectoryEntries, runFileInSubprocess } from './tests.ts';
 
-const ROOT_PATH = path.resolve(import.meta.dirname, "..", "..");
-const TESTS_ROOT_PATH = path.join(ROOT_PATH, "tests");
+const ROOT_PATH = path.resolve(import.meta.dirname, '..', '..');
+const TESTS_ROOT_PATH = path.join(ROOT_PATH, 'tests');
 
 function populateSuite(
-  dir: string
+  dir: string,
 ) {
   const { directories, files } = listDirectoryEntries(dir);
 
@@ -20,6 +20,6 @@ function populateSuite(
   }
 }
 
-populateSuite(path.join(TESTS_ROOT_PATH, "harness"));
-populateSuite(path.join(TESTS_ROOT_PATH, "js-native-api"));
-populateSuite(path.join(TESTS_ROOT_PATH, "node-api"));
+populateSuite(path.join(TESTS_ROOT_PATH, 'harness'));
+populateSuite(path.join(TESTS_ROOT_PATH, 'js-native-api'));
+populateSuite(path.join(TESTS_ROOT_PATH, 'node-api'));

--- a/implementors/node/tests.ts
+++ b/implementors/node/tests.ts
@@ -1,51 +1,51 @@
-import assert from "node:assert";
-import { spawn } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 assert(
-  typeof import.meta.dirname === "string",
-  "Expecting a recent Node.js runtime API version"
+  typeof import.meta.dirname === 'string',
+  'Expecting a recent Node.js runtime API version',
 );
 
-const ROOT_PATH = path.resolve(import.meta.dirname, "..", "..");
-const TESTS_ROOT_PATH = path.join(ROOT_PATH, "tests");
+const ROOT_PATH = path.resolve(import.meta.dirname, '..', '..');
+const TESTS_ROOT_PATH = path.join(ROOT_PATH, 'tests');
 const FEATURES_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "features.js"
+  'implementors',
+  'node',
+  'features.js',
 );
 const ASSERT_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "assert.js"
+  'implementors',
+  'node',
+  'assert.js',
 );
 const LOAD_ADDON_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "load-addon.js"
+  'implementors',
+  'node',
+  'load-addon.js',
 );
-const GC_MODULE_PATH = path.join(ROOT_PATH, "implementors", "node", "gc.js");
+const GC_MODULE_PATH = path.join(ROOT_PATH, 'implementors', 'node', 'gc.js');
 const MUST_CALL_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "must-call.js"
+  'implementors',
+  'node',
+  'must-call.js',
 );
 const SKIP_TEST_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "skip-test.js"
+  'implementors',
+  'node',
+  'skip-test.js',
 );
 const NAPI_VERSION_MODULE_PATH = path.join(
   ROOT_PATH,
-  "implementors",
-  "node",
-  "napi-version.js"
+  'implementors',
+  'node',
+  'napi-version.js',
 );
 
 export function listDirectoryEntries(dir: string) {
@@ -56,7 +56,7 @@ export function listDirectoryEntries(dir: string) {
   for (const entry of entries) {
     if (entry.isDirectory()) {
       directories.push(entry.name);
-    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
       files.push(entry.name);
     }
   }
@@ -69,62 +69,62 @@ export function listDirectoryEntries(dir: string) {
 
 export function runFileInSubprocess(
   cwd: string,
-  filePath: string
+  filePath: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
       [
         // Using file scheme prefix when to enable imports on Windows
-        "--expose-gc",
-        "--import",
-        "file://" + FEATURES_MODULE_PATH,
-        "--import",
-        "file://" + ASSERT_MODULE_PATH,
-        "--import",
-        "file://" + LOAD_ADDON_MODULE_PATH,
-        "--import",
-        "file://" + GC_MODULE_PATH,
-        "--import",
-        "file://" + MUST_CALL_MODULE_PATH,
-        "--import",
-        "file://" + SKIP_TEST_MODULE_PATH,
-        "--import",
-        "file://" + NAPI_VERSION_MODULE_PATH,
+        '--expose-gc',
+        '--import',
+        'file://' + FEATURES_MODULE_PATH,
+        '--import',
+        'file://' + ASSERT_MODULE_PATH,
+        '--import',
+        'file://' + LOAD_ADDON_MODULE_PATH,
+        '--import',
+        'file://' + GC_MODULE_PATH,
+        '--import',
+        'file://' + MUST_CALL_MODULE_PATH,
+        '--import',
+        'file://' + SKIP_TEST_MODULE_PATH,
+        '--import',
+        'file://' + NAPI_VERSION_MODULE_PATH,
         filePath,
       ],
-      { cwd }
+      { cwd },
     );
 
-    let stderrOutput = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk) => {
+    let stderrOutput = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
       stderrOutput += chunk;
     });
 
     child.stdout.pipe(process.stdout);
 
-    child.on("error", reject);
+    child.on('error', reject);
 
-    child.on("close", (code, signal) => {
+    child.on('close', (code, signal) => {
       if (code === 0) {
         resolve();
         return;
       }
 
       const reason =
-        code !== null ? `exit code ${code}` : `signal ${signal ?? "unknown"}`;
+        code !== null ? `exit code ${code}` : `signal ${signal ?? 'unknown'}`;
       const trimmedStderr = stderrOutput.trim();
-      const stderrSuffix = trimmedStderr
-        ? `\n--- stderr ---\n${trimmedStderr}\n--- end stderr ---`
-        : "";
+      const stderrSuffix = trimmedStderr ?
+        `\n--- stderr ---\n${trimmedStderr}\n--- end stderr ---` :
+        '';
       reject(
         new Error(
           `Test file ${path.relative(
             TESTS_ROOT_PATH,
-            filePath
-          )} failed (${reason})${stderrSuffix}`
-        )
+            filePath,
+          )} failed (${reason})${stderrSuffix}`,
+        ),
       );
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^24.10.1",
         "eslint": "^9.39.1",
         "globals": "^17.4.0",
@@ -238,6 +239,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^24.10.1",
     "eslint": "^9.39.1",
     "globals": "^17.4.0",

--- a/scripts/update-headers.mjs
+++ b/scripts/update-headers.mjs
@@ -5,26 +5,26 @@
 //
 // Usage: node scripts/update-headers.mjs [--branch <branch>]
 
-import { execFile } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const ROOT = path.resolve(import.meta.dirname, "..");
-const INCLUDE_DIR = path.join(ROOT, "include");
-const DEF_DIR = path.join(INCLUDE_DIR, "def");
+const ROOT = path.resolve(import.meta.dirname, '..');
+const INCLUDE_DIR = path.join(ROOT, 'include');
+const DEF_DIR = path.join(INCLUDE_DIR, 'def');
 
 const HEADER_FILES = [
-  "js_native_api.h",
-  "js_native_api_types.h",
-  "node_api.h",
-  "node_api_types.h",
+  'js_native_api.h',
+  'js_native_api_types.h',
+  'node_api.h',
+  'node_api_types.h',
 ];
 
 function parseBranch() {
-  const idx = process.argv.indexOf("--branch");
-  return idx !== -1 && process.argv[idx + 1]
-    ? process.argv[idx + 1]
-    : "main";
+  const idx = process.argv.indexOf('--branch');
+  return idx !== -1 && process.argv[idx + 1] ?
+    process.argv[idx + 1] :
+    'main';
 }
 
 async function downloadHeaders(branch) {
@@ -37,7 +37,7 @@ async function downloadHeaders(branch) {
         throw new Error(`Failed to download ${url}: ${response.status}`);
       }
       return { file, content: await response.text() };
-    })
+    }),
   );
 
   fs.mkdirSync(INCLUDE_DIR, { recursive: true });
@@ -49,47 +49,47 @@ async function downloadHeaders(branch) {
 
 function detectLatestStableVersion() {
   const content = fs.readFileSync(
-    path.join(INCLUDE_DIR, "js_native_api.h"),
-    "utf8"
+    path.join(INCLUDE_DIR, 'js_native_api.h'),
+    'utf8',
   );
   const nodeApiContent = fs.readFileSync(
-    path.join(INCLUDE_DIR, "node_api.h"),
-    "utf8"
+    path.join(INCLUDE_DIR, 'node_api.h'),
+    'utf8',
   );
   const combined = content + nodeApiContent;
   const versions = [...combined.matchAll(/NAPI_VERSION >= (\d+)/g)].map(
-    (m) => Number(m[1])
+    (m) => Number(m[1]),
   );
   return Math.max(...versions);
 }
 
 function runClang(headerFile, { experimental = false, napiVersion } = {}) {
   const args = [
-    ...(experimental ? ["-D", "NAPI_EXPERIMENTAL"] : []),
-    ...(napiVersion ? ["-D", `NAPI_VERSION=${napiVersion}`] : []),
-    "-Xclang",
-    "-ast-dump=json",
-    "-fsyntax-only",
-    "-I",
+    ...(experimental ? ['-D', 'NAPI_EXPERIMENTAL'] : []),
+    ...(napiVersion ? ['-D', `NAPI_VERSION=${napiVersion}`] : []),
+    '-Xclang',
+    '-ast-dump=json',
+    '-fsyntax-only',
+    '-I',
     INCLUDE_DIR,
     path.join(INCLUDE_DIR, headerFile),
   ];
   return new Promise((resolve, reject) => {
     execFile(
-      "clang",
+      'clang',
       args,
       { maxBuffer: 10 * 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error) {
           reject(
             new Error(
-              `clang failed on ${headerFile}: ${error.message}\n${stderr}`
-            )
+              `clang failed on ${headerFile}: ${error.message}\n${stderr}`,
+            ),
           );
           return;
         }
         resolve(stdout);
-      }
+      },
     );
   });
 }
@@ -98,20 +98,20 @@ function extractSymbols(astJson) {
   const ast = JSON.parse(astJson);
   return new Set(
     ast.inner
-      .filter((node) => node.kind === "FunctionDecl")
-      .map((node) => node.name)
+      .filter((node) => node.kind === 'FunctionDecl')
+      .map((node) => node.name),
   );
 }
 
 function generateDef(symbols) {
-  return [...symbols].sort().join("\n") + "\n";
+  return [...symbols].sort().join('\n') + '\n';
 }
 
 function writeDef(filename, symbols) {
   const defPath = path.join(DEF_DIR, filename);
   fs.writeFileSync(defPath, generateDef(symbols));
   console.log(
-    `Generated ${path.relative(ROOT, defPath)} (${symbols.size} symbols)`
+    `Generated ${path.relative(ROOT, defPath)} (${symbols.size} symbols)`,
   );
 }
 
@@ -121,10 +121,10 @@ async function generateDefFiles() {
 
   const [jsNativeApiAst, nodeApiAst, jsNativeApiExpAst, nodeApiExpAst] =
     await Promise.all([
-      runClang("js_native_api.h", { napiVersion: latestVersion }),
-      runClang("node_api.h", { napiVersion: latestVersion }),
-      runClang("js_native_api.h", { experimental: true }),
-      runClang("node_api.h", { experimental: true }),
+      runClang('js_native_api.h', { napiVersion: latestVersion }),
+      runClang('node_api.h', { napiVersion: latestVersion }),
+      runClang('js_native_api.h', { experimental: true }),
+      runClang('node_api.h', { experimental: true }),
     ]);
 
   const jsNativeApiStable = extractSymbols(jsNativeApiAst);
@@ -139,15 +139,15 @@ async function generateDefFiles() {
 
   fs.mkdirSync(DEF_DIR, { recursive: true });
 
-  writeDef("js_native_api.def", jsNativeApiStable);
-  writeDef("node_api.def", nodeApiStable);
-  writeDef("js_native_api_experimental.def", jsNativeApiExp);
-  writeDef("node_api_experimental.def", nodeApiExp);
+  writeDef('js_native_api.def', jsNativeApiStable);
+  writeDef('node_api.def', nodeApiStable);
+  writeDef('js_native_api_experimental.def', jsNativeApiExp);
+  writeDef('node_api_experimental.def', nodeApiExp);
 }
 
 const branch = parseBranch();
 console.log(`Downloading headers from nodejs/node@${branch}...`);
 await downloadHeaders(branch);
-console.log("\nGenerating .def files via clang...");
+console.log('\nGenerating .def files via clang...');
 await generateDefFiles();
-console.log("\nDone.");
+console.log('\nDone.');

--- a/tests/harness/features.js
+++ b/tests/harness/features.js
@@ -2,7 +2,7 @@
 
 assert.ok(
   typeof experimentalFeatures === 'object' && experimentalFeatures !== null,
-  'Expected a global experimentalFeatures object'
+  'Expected a global experimentalFeatures object',
 );
 
 // Every expected feature must be declared as a boolean (true or false).
@@ -18,6 +18,6 @@ for (const feature of expectedFeatures) {
   assert.strictEqual(
     typeof experimentalFeatures[feature],
     'boolean',
-    `Expected experimentalFeatures.${feature} to be a boolean`
+    `Expected experimentalFeatures.${feature} to be a boolean`,
   );
 }

--- a/tests/js-native-api/2_function_arguments/test.js
+++ b/tests/js-native-api/2_function_arguments/test.js
@@ -2,5 +2,5 @@ const addon = loadAddon('2_function_arguments');
 
 const { add } = addon;
 
-assert(typeof add === "function");
+assert(typeof add === 'function');
 assert(add(3, 5) === 8);

--- a/tests/js-native-api/test_conversions/test.js
+++ b/tests/js-native-api/test_conversions/test.js
@@ -1,11 +1,11 @@
-"use strict";
-const test = loadAddon("test_conversions");
+'use strict';
+const test = loadAddon('test_conversions');
 
 const boolExpected = /boolean was expected/;
 const numberExpected = /number was expected/;
 const stringExpected = /string was expected/;
 
-const testSym = Symbol("test");
+const testSym = Symbol('test');
 
 assert.strictEqual(test.asBool(false), false);
 assert.strictEqual(test.asBool(true), true);
@@ -13,11 +13,11 @@ assert.throws(() => test.asBool(undefined), boolExpected);
 assert.throws(() => test.asBool(null), boolExpected);
 assert.throws(() => test.asBool(Number.NaN), boolExpected);
 assert.throws(() => test.asBool(0), boolExpected);
-assert.throws(() => test.asBool(""), boolExpected);
-assert.throws(() => test.asBool("0"), boolExpected);
+assert.throws(() => test.asBool(''), boolExpected);
+assert.throws(() => test.asBool('0'), boolExpected);
 assert.throws(() => test.asBool(1), boolExpected);
-assert.throws(() => test.asBool("1"), boolExpected);
-assert.throws(() => test.asBool("true"), boolExpected);
+assert.throws(() => test.asBool('1'), boolExpected);
+assert.throws(() => test.asBool('true'), boolExpected);
 assert.throws(() => test.asBool({}), boolExpected);
 assert.throws(() => test.asBool([]), boolExpected);
 assert.throws(() => test.asBool(testSym), boolExpected);
@@ -34,8 +34,8 @@ assert.throws(() => test.asBool(testSym), boolExpected);
   assert.throws(() => asInt(undefined), numberExpected);
   assert.throws(() => asInt(null), numberExpected);
   assert.throws(() => asInt(false), numberExpected);
-  assert.throws(() => asInt(""), numberExpected);
-  assert.throws(() => asInt("1"), numberExpected);
+  assert.throws(() => asInt(''), numberExpected);
+  assert.throws(() => asInt('1'), numberExpected);
   assert.throws(() => asInt({}), numberExpected);
   assert.throws(() => asInt([]), numberExpected);
   assert.throws(() => asInt(testSym), numberExpected);
@@ -57,14 +57,14 @@ assert.ok(Number.isNaN(test.asDouble(Number.NaN)));
 assert.throws(() => test.asDouble(undefined), numberExpected);
 assert.throws(() => test.asDouble(null), numberExpected);
 assert.throws(() => test.asDouble(false), numberExpected);
-assert.throws(() => test.asDouble(""), numberExpected);
-assert.throws(() => test.asDouble("1"), numberExpected);
+assert.throws(() => test.asDouble(''), numberExpected);
+assert.throws(() => test.asDouble('1'), numberExpected);
 assert.throws(() => test.asDouble({}), numberExpected);
 assert.throws(() => test.asDouble([]), numberExpected);
 assert.throws(() => test.asDouble(testSym), numberExpected);
 
-assert.strictEqual(test.asString(""), "");
-assert.strictEqual(test.asString("test"), "test");
+assert.strictEqual(test.asString(''), '');
+assert.strictEqual(test.asString('test'), 'test');
 assert.throws(() => test.asString(undefined), stringExpected);
 assert.throws(() => test.asString(null), stringExpected);
 assert.throws(() => test.asString(false), stringExpected);
@@ -78,8 +78,8 @@ assert.throws(() => test.asString(testSym), stringExpected);
 assert.strictEqual(test.toBool(true), true);
 assert.strictEqual(test.toBool(1), true);
 assert.strictEqual(test.toBool(-1), true);
-assert.strictEqual(test.toBool("true"), true);
-assert.strictEqual(test.toBool("false"), true);
+assert.strictEqual(test.toBool('true'), true);
+assert.strictEqual(test.toBool('false'), true);
 assert.strictEqual(test.toBool({}), true);
 assert.strictEqual(test.toBool([]), true);
 assert.strictEqual(test.toBool(testSym), true);
@@ -88,19 +88,19 @@ assert.strictEqual(test.toBool(undefined), false);
 assert.strictEqual(test.toBool(null), false);
 assert.strictEqual(test.toBool(0), false);
 assert.strictEqual(test.toBool(Number.NaN), false);
-assert.strictEqual(test.toBool(""), false);
+assert.strictEqual(test.toBool(''), false);
 
 assert.strictEqual(test.toNumber(0), 0);
 assert.strictEqual(test.toNumber(1), 1);
 assert.strictEqual(test.toNumber(1.1), 1.1);
 assert.strictEqual(test.toNumber(-1), -1);
-assert.strictEqual(test.toNumber("0"), 0);
-assert.strictEqual(test.toNumber("1"), 1);
-assert.strictEqual(test.toNumber("1.1"), 1.1);
+assert.strictEqual(test.toNumber('0'), 0);
+assert.strictEqual(test.toNumber('1'), 1);
+assert.strictEqual(test.toNumber('1.1'), 1.1);
 assert.strictEqual(test.toNumber([]), 0);
 assert.strictEqual(test.toNumber(false), 0);
 assert.strictEqual(test.toNumber(null), 0);
-assert.strictEqual(test.toNumber(""), 0);
+assert.strictEqual(test.toNumber(''), 0);
 assert.ok(Number.isNaN(test.toNumber(Number.NaN)));
 assert.ok(Number.isNaN(test.toNumber({})));
 assert.ok(Number.isNaN(test.toNumber(undefined)));
@@ -112,104 +112,104 @@ assert.deepStrictEqual([], test.toObject([]));
 assert.deepStrictEqual([1, 2, 3], test.toObject([1, 2, 3]));
 assert.deepStrictEqual(new Boolean(false), test.toObject(false));
 assert.deepStrictEqual(new Boolean(true), test.toObject(true));
-assert.deepStrictEqual(new String(""), test.toObject(""));
+assert.deepStrictEqual(new String(''), test.toObject(''));
 assert.deepStrictEqual(new Number(0), test.toObject(0));
 assert.deepStrictEqual(new Number(Number.NaN), test.toObject(Number.NaN));
 assert.deepStrictEqual(new Object(testSym), test.toObject(testSym));
 assert.notStrictEqual(test.toObject(false), false);
 assert.notStrictEqual(test.toObject(true), true);
-assert.notStrictEqual(test.toObject(""), "");
+assert.notStrictEqual(test.toObject(''), '');
 assert.notStrictEqual(test.toObject(0), 0);
 assert.ok(!Number.isNaN(test.toObject(Number.NaN)));
 
-assert.strictEqual(test.toString(""), "");
-assert.strictEqual(test.toString("test"), "test");
-assert.strictEqual(test.toString(undefined), "undefined");
-assert.strictEqual(test.toString(null), "null");
-assert.strictEqual(test.toString(false), "false");
-assert.strictEqual(test.toString(true), "true");
-assert.strictEqual(test.toString(0), "0");
-assert.strictEqual(test.toString(1.1), "1.1");
-assert.strictEqual(test.toString(Number.NaN), "NaN");
-assert.strictEqual(test.toString({}), "[object Object]");
-assert.strictEqual(test.toString({ toString: () => "test" }), "test");
-assert.strictEqual(test.toString([]), "");
-assert.strictEqual(test.toString([1, 2, 3]), "1,2,3");
+assert.strictEqual(test.toString(''), '');
+assert.strictEqual(test.toString('test'), 'test');
+assert.strictEqual(test.toString(undefined), 'undefined');
+assert.strictEqual(test.toString(null), 'null');
+assert.strictEqual(test.toString(false), 'false');
+assert.strictEqual(test.toString(true), 'true');
+assert.strictEqual(test.toString(0), '0');
+assert.strictEqual(test.toString(1.1), '1.1');
+assert.strictEqual(test.toString(Number.NaN), 'NaN');
+assert.strictEqual(test.toString({}), '[object Object]');
+assert.strictEqual(test.toString({ toString: () => 'test' }), 'test');
+assert.strictEqual(test.toString([]), '');
+assert.strictEqual(test.toString([1, 2, 3]), '1,2,3');
 assert.throws(() => test.toString(testSym), TypeError);
 
 assert.deepStrictEqual(test.testNull.getValueBool(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "A boolean was expected",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'A boolean was expected',
 });
 
 assert.deepStrictEqual(test.testNull.getValueInt32(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "A number was expected",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'A number was expected',
 });
 
 assert.deepStrictEqual(test.testNull.getValueUint32(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "A number was expected",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'A number was expected',
 });
 
 assert.deepStrictEqual(test.testNull.getValueInt64(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "A number was expected",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'A number was expected',
 });
 
 assert.deepStrictEqual(test.testNull.getValueDouble(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "A number was expected",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'A number was expected',
 });
 
 assert.deepStrictEqual(test.testNull.coerceToBool(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "napi_ok",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'napi_ok',
 });
 
 assert.deepStrictEqual(test.testNull.coerceToObject(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "napi_ok",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'napi_ok',
 });
 
 assert.deepStrictEqual(test.testNull.coerceToString(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
-  inputTypeCheck: "napi_ok",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
+  inputTypeCheck: 'napi_ok',
 });
 
 assert.deepStrictEqual(test.testNull.getValueStringUtf8(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  wrongTypeIn: "A string was expected",
-  bufAndOutLengthIsNull: "Invalid argument",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  wrongTypeIn: 'A string was expected',
+  bufAndOutLengthIsNull: 'Invalid argument',
 });
 
 assert.deepStrictEqual(test.testNull.getValueStringLatin1(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  wrongTypeIn: "A string was expected",
-  bufAndOutLengthIsNull: "Invalid argument",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  wrongTypeIn: 'A string was expected',
+  bufAndOutLengthIsNull: 'Invalid argument',
 });
 
 assert.deepStrictEqual(test.testNull.getValueStringUtf16(), {
-  envIsNull: "Invalid argument",
-  valueIsNull: "Invalid argument",
-  wrongTypeIn: "A string was expected",
-  bufAndOutLengthIsNull: "Invalid argument",
+  envIsNull: 'Invalid argument',
+  valueIsNull: 'Invalid argument',
+  wrongTypeIn: 'A string was expected',
+  bufAndOutLengthIsNull: 'Invalid argument',
 });

--- a/tests/js-native-api/test_dataview/test.js
+++ b/tests/js-native-api/test_dataview/test.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
 // Testing api calls for dataview
-const test_dataview = loadAddon("test_dataview");
+const test_dataview = loadAddon('test_dataview');
 
 // Test for creating dataview with ArrayBuffer
 {

--- a/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
+++ b/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 // napi_create_dataview accepts a SharedArrayBuffer-backed buffer only on newer
 // Node.js releases (see implementors/node/features.js).
@@ -7,7 +7,7 @@ if (!experimentalFeatures.dataviewSharedArrayBuffer) {
 }
 
 // Testing api calls for dataview backed by a SharedArrayBuffer
-const test_dataview = loadAddon("test_dataview");
+const test_dataview = loadAddon('test_dataview');
 
 // Test for creating dataview with SharedArrayBuffer
 {

--- a/tests/js-native-api/test_error/test.js
+++ b/tests/js-native-api/test_error/test.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
-const test_error = loadAddon("test_error");
-const theError = new Error("Some error");
-const theTypeError = new TypeError("Some type error");
-const theSyntaxError = new SyntaxError("Some syntax error");
-const theRangeError = new RangeError("Some type error");
-const theReferenceError = new ReferenceError("Some reference error");
-const theURIError = new URIError("Some URI error");
-const theEvalError = new EvalError("Some eval error");
+const test_error = loadAddon('test_error');
+const theError = new Error('Some error');
+const theTypeError = new TypeError('Some type error');
+const theSyntaxError = new SyntaxError('Some syntax error');
+const theRangeError = new RangeError('Some type error');
+const theReferenceError = new ReferenceError('Some reference error');
+const theURIError = new URIError('Some URI error');
+const theEvalError = new EvalError('Some eval error');
 
 class MyError extends Error {}
-const myError = new MyError("Some MyError");
+const myError = new MyError('Some MyError');
 
 // Test that native error object is correctly classed
 assert.strictEqual(test_error.checkError(theError), true);
@@ -40,7 +40,7 @@ assert.strictEqual(test_error.checkError(myError), true);
 assert.strictEqual(test_error.checkError({}), false);
 
 // Test that non-error primitive is correctly classed
-assert.strictEqual(test_error.checkError("non-object"), false);
+assert.strictEqual(test_error.checkError('non-object'), false);
 
 assert.throws(() => {
   test_error.throwExistingError();
@@ -62,7 +62,7 @@ assert.throws(() => {
   test_error.throwSyntaxError();
 }, /^SyntaxError: syntax error$/);
 
-[42, {}, [], Symbol("xyzzy"), true, "ball", undefined, null, NaN].forEach(
+[42, {}, [], Symbol('xyzzy'), true, 'ball', undefined, null, NaN].forEach(
   (value) =>
     assert.throws(
       () => test_error.throwArbitrary(value),
@@ -74,79 +74,79 @@ assert.throws(() => {
 );
 
 assert.throws(() => test_error.throwErrorCode(), {
-  code: "ERR_TEST_CODE",
-  message: "Error [error]",
+  code: 'ERR_TEST_CODE',
+  message: 'Error [error]',
 });
 
 assert.throws(() => test_error.throwRangeErrorCode(), {
-  code: "ERR_TEST_CODE",
-  message: "RangeError [range error]",
+  code: 'ERR_TEST_CODE',
+  message: 'RangeError [range error]',
 });
 
 assert.throws(() => test_error.throwTypeErrorCode(), {
-  code: "ERR_TEST_CODE",
-  message: "TypeError [type error]",
+  code: 'ERR_TEST_CODE',
+  message: 'TypeError [type error]',
 });
 
 assert.throws(() => test_error.throwSyntaxErrorCode(), {
-  code: "ERR_TEST_CODE",
-  message: "SyntaxError [syntax error]",
+  code: 'ERR_TEST_CODE',
+  message: 'SyntaxError [syntax error]',
 });
 
 let error = test_error.createError();
-assert.ok(error instanceof Error, "expected error to be an instance of Error");
-assert.strictEqual(error.message, "error");
+assert.ok(error instanceof Error, 'expected error to be an instance of Error');
+assert.strictEqual(error.message, 'error');
 
 error = test_error.createRangeError();
 assert.ok(
   error instanceof RangeError,
-  "expected error to be an instance of RangeError",
+  'expected error to be an instance of RangeError',
 );
-assert.strictEqual(error.message, "range error");
+assert.strictEqual(error.message, 'range error');
 
 error = test_error.createTypeError();
 assert.ok(
   error instanceof TypeError,
-  "expected error to be an instance of TypeError",
+  'expected error to be an instance of TypeError',
 );
-assert.strictEqual(error.message, "type error");
+assert.strictEqual(error.message, 'type error');
 
 error = test_error.createSyntaxError();
 assert.ok(
   error instanceof SyntaxError,
-  "expected error to be an instance of SyntaxError",
+  'expected error to be an instance of SyntaxError',
 );
-assert.strictEqual(error.message, "syntax error");
+assert.strictEqual(error.message, 'syntax error');
 
 error = test_error.createErrorCode();
-assert.ok(error instanceof Error, "expected error to be an instance of Error");
-assert.strictEqual(error.code, "ERR_TEST_CODE");
-assert.strictEqual(error.message, "Error [error]");
-assert.strictEqual(error.name, "Error");
+assert.ok(error instanceof Error, 'expected error to be an instance of Error');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.message, 'Error [error]');
+assert.strictEqual(error.name, 'Error');
 
 error = test_error.createRangeErrorCode();
 assert.ok(
   error instanceof RangeError,
-  "expected error to be an instance of RangeError",
+  'expected error to be an instance of RangeError',
 );
-assert.strictEqual(error.message, "RangeError [range error]");
-assert.strictEqual(error.code, "ERR_TEST_CODE");
-assert.strictEqual(error.name, "RangeError");
+assert.strictEqual(error.message, 'RangeError [range error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'RangeError');
 
 error = test_error.createTypeErrorCode();
 assert.ok(
   error instanceof TypeError,
-  "expected error to be an instance of TypeError",
+  'expected error to be an instance of TypeError',
 );
-assert.strictEqual(error.message, "TypeError [type error]");
-assert.strictEqual(error.code, "ERR_TEST_CODE");
-assert.strictEqual(error.name, "TypeError");
+assert.strictEqual(error.message, 'TypeError [type error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'TypeError');
 
 error = test_error.createSyntaxErrorCode();
 assert.ok(
   error instanceof SyntaxError,
-  "expected error to be an instance of SyntaxError",
+  'expected error to be an instance of SyntaxError',
 );
-assert.strictEqual(error.message, "SyntaxError [syntax error]");
-assert.strictEqual(error.code, "ERR_TEST_CODE");
-assert.strictEqual(error.name, "SyntaxError");
+assert.strictEqual(error.message, 'SyntaxError [syntax error]');
+assert.strictEqual(error.code, 'ERR_TEST_CODE');
+assert.strictEqual(error.name, 'SyntaxError');

--- a/tests/js-native-api/test_function/test.js
+++ b/tests/js-native-api/test_function/test.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 // Flags: --expose-gc
 
 // Testing api calls for function
-const test_function = loadAddon("test_function");
+const test_function = loadAddon('test_function');
 
 function func1() {
   return 1;
@@ -24,8 +24,8 @@ function func4(input) {
 }
 assert.strictEqual(test_function.TestCall(func4, 1), 2);
 
-assert.strictEqual(test_function.TestName.name, "Name");
-assert.strictEqual(test_function.TestNameShort.name, "Name_");
+assert.strictEqual(test_function.TestName.name, 'Name');
+assert.strictEqual(test_function.TestNameShort.name, 'Name_');
 
 let tracked_function = test_function.MakeTrackedFunction(mustCall());
 assert(!!tracked_function);
@@ -33,13 +33,13 @@ tracked_function = null;
 gc();
 
 assert.deepStrictEqual(test_function.TestCreateFunctionParameters(), {
-  envIsNull: "Invalid argument",
-  nameIsNull: "napi_ok",
-  cbIsNull: "Invalid argument",
-  resultIsNull: "Invalid argument",
+  envIsNull: 'Invalid argument',
+  nameIsNull: 'napi_ok',
+  cbIsNull: 'Invalid argument',
+  resultIsNull: 'Invalid argument',
 });
 
 assert.throws(() => test_function.TestBadReturnExceptionPending(), {
-  code: "throwing exception",
-  name: "Error",
+  code: 'throwing exception',
+  name: 'Error',
 });

--- a/tests/js-native-api/test_sharedarraybuffer/test.js
+++ b/tests/js-native-api/test_sharedarraybuffer/test.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
 // SharedArrayBuffer support is an experimental feature.
 if (!experimentalFeatures.sharedArrayBuffer) {
   skipTest();
 }
 
-const test_sharedarraybuffer = loadAddon("test_sharedarraybuffer");
+const test_sharedarraybuffer = loadAddon('test_sharedarraybuffer');
 
 {
   const sab = new SharedArrayBuffer(16);
@@ -86,6 +86,6 @@ const test_sharedarraybuffer = loadAddon("test_sharedarraybuffer");
     () => {
       test_sharedarraybuffer.TestGetSharedArrayBufferInfo({});
     },
-    { name: "Error", message: "Invalid argument" },
+    { name: 'Error', message: 'Invalid argument' },
   );
 }

--- a/tests/js-native-api/test_string/test.js
+++ b/tests/js-native-api/test_string/test.js
@@ -1,26 +1,26 @@
-"use strict";
+'use strict';
 
 // Testing api calls for string
-const test_string = loadAddon("test_string");
+const test_string = loadAddon('test_string');
 // The insufficient buffer test case allocates a buffer of size 4, including
 // the null terminator.
 const kInsufficientIdx = 3;
 
 const asciiCases = [
-  "",
-  "hello world",
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+  '',
+  'hello world',
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
   "?!@#$%^&*()_+-=[]{}/.,<>'\"\\",
 ];
 
 const latin1Cases = [
   {
-    str: "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿",
+    str: '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿',
     utf8Length: 62,
     utf8InsufficientIdx: 1,
   },
   {
-    str: "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ",
+    str: 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ',
     utf8Length: 126,
     utf8InsufficientIdx: 1,
   },
@@ -28,7 +28,7 @@ const latin1Cases = [
 
 const unicodeCases = [
   {
-    str: "\u{2003}\u{2101}\u{2001}\u{202}\u{2011}",
+    str: '\u{2003}\u{2101}\u{2001}\u{202}\u{2011}',
     utf8Length: 14,
     utf8InsufficientIdx: 1,
   },
@@ -39,7 +39,7 @@ function testLatin1Cases(str) {
   assert.strictEqual(test_string.TestLatin1AutoLength(str), str);
   assert.strictEqual(test_string.Latin1Length(str), str.length);
 
-  if (str !== "") {
+  if (str !== '') {
     assert.strictEqual(
       test_string.TestLatin1Insufficient(str),
       str.slice(0, kInsufficientIdx),
@@ -55,7 +55,7 @@ function testUnicodeCases(str, utf8Length, utf8InsufficientIdx) {
   assert.strictEqual(test_string.Utf8Length(str), utf8Length);
   assert.strictEqual(test_string.Utf16Length(str), str.length);
 
-  if (str !== "") {
+  if (str !== '') {
     assert.strictEqual(
       test_string.TestUtf8Insufficient(str),
       str.slice(0, utf8InsufficientIdx),
@@ -91,4 +91,4 @@ assert.throws(() => {
   test_string.TestLargeUtf16();
 }, /^Error: Invalid argument$/);
 
-test_string.TestMemoryCorruption(" ".repeat(64 * 1024));
+test_string.TestMemoryCorruption(' '.repeat(64 * 1024));

--- a/tests/js-native-api/test_string/test_null.js
+++ b/tests/js-native-api/test_string/test_null.js
@@ -1,13 +1,13 @@
-"use strict";
+'use strict';
 
 // Test passing NULL to object-related Node-APIs.
-const { testNull } = loadAddon("test_string");
+const { testNull } = loadAddon('test_string');
 
 const expectedResult = {
-  envIsNull: "Invalid argument",
-  stringIsNullNonZeroLength: "Invalid argument",
-  stringIsNullZeroLength: "napi_ok",
-  resultIsNull: "Invalid argument",
+  envIsNull: 'Invalid argument',
+  stringIsNullNonZeroLength: 'Invalid argument',
+  stringIsNullZeroLength: 'napi_ok',
+  resultIsNull: 'Invalid argument',
 };
 
 assert.deepStrictEqual(expectedResult, testNull.test_create_latin1());

--- a/tests/js-native-api/test_string/test_v10.js
+++ b/tests/js-native-api/test_string/test_v10.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 // Tests for Node-API version >= 10 APIs:
 // node_api_create_external_string_latin1/utf16 and
@@ -7,23 +7,23 @@ if (Number(napiVersion) < 10) {
   skipTest();
 }
 
-const test_string_v10 = loadAddon("test_string_v10");
+const test_string_v10 = loadAddon('test_string_v10');
 
 const asciiCases = [
-  "",
-  "hello world",
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+  '',
+  'hello world',
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
   "?!@#$%^&*()_+-=[]{}/.,<>'\"\\",
 ];
 
 const latin1Cases = [
   {
-    str: "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿",
+    str: '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿',
     utf8Length: 62,
     utf8InsufficientIdx: 1,
   },
   {
-    str: "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ",
+    str: 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ',
     utf8Length: 126,
     utf8InsufficientIdx: 1,
   },
@@ -31,7 +31,7 @@ const latin1Cases = [
 
 const unicodeCases = [
   {
-    str: "\u{2003}\u{2101}\u{2001}\u{202}\u{2011}",
+    str: '\u{2003}\u{2101}\u{2001}\u{202}\u{2011}',
     utf8Length: 14,
     utf8InsufficientIdx: 1,
   },

--- a/tests/js-native-api/test_typedarray/test.js
+++ b/tests/js-native-api/test_typedarray/test.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
 // Testing api calls for arrays
-const test_typedarray = loadAddon("test_typedarray");
+const test_typedarray = loadAddon('test_typedarray');
 
 const byteArray = new Uint8Array(3);
 byteArray[0] = 0;
@@ -39,7 +39,7 @@ assert.strictEqual(externalResult[2], 2);
 // Float16Array is an ES2025 addition; not exposed by default in older V8
 // versions (e.g. those shipped with Node 20.x / 22.x). Detect at runtime and
 // only exercise the Float16Array code paths when the engine supports it.
-const hasFloat16Array = typeof Float16Array !== "undefined";
+const hasFloat16Array = typeof Float16Array !== 'undefined';
 
 // Validate creation of all kinds of TypedArrays
 const buffer = new ArrayBuffer(128);
@@ -64,7 +64,7 @@ arrayTypes.forEach((currentType) => {
 
   assert.ok(
     theArray instanceof currentType,
-    "Type of new array should match that of the template. " +
+    'Type of new array should match that of the template. ' +
       `Expected type: ${currentType.name}, ` +
       `actual type: ${template.constructor.name}`,
   );


### PR DESCRIPTION
Adds machine-enforced JS/TS formatting via `@stylistic/eslint-plugin`, with rules mirrored from [nodejs/node's eslint config](https://github.com/nodejs/node/blob/main/eslint.config.mjs) — single quotes, trailing commas, 2-space indent, 120 max-len.

Two commits:
1. **add @stylistic rules** — dependency + config (the only commit to review).
2. **format codebase** — mechanical `eslint --fix`, no behavior change.

Deviation from upstream: this repo has TypeScript, so it uses the unified `@stylistic/eslint-plugin` instead of the JS-only `-js` package (same rules).

No new CI — the existing `lint.yml` runs `npm run lint` on every push/PR, so it now enforces these rules. `npm run lint` and `npm run node:test` (40/40) pass.