### PR TITLE
chore: remove redundant 'use strict' from test files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Node-API Conformance Test Suite: A pure ECMAScript test suite for Node-API imple
 
 ## General Principles
 - **Keep it minimal**: Avoid unnecessary dependencies, configuration, or complexity
-- **Pure ECMAScript tests**: To lower the barrier for implementors to run the tests, all tests are written as single files of pure ECMAScript, with no import / export statements and no use of Node.js runtime APIs outside of the language standard (such as `process`, `require`, `node:*` modules).
+- **Pure ECMAScript tests**: To lower the barrier for implementors to run the tests, all tests are written as single files of pure ECMAScript, with no import / export statements and no use of Node.js runtime APIs outside of the language standard (such as `process`, `require`, `node:*` modules). Test files are evaluated as ES modules, which are always in strict mode, so drop the `'use strict'` directive when porting a file that carries one.
 - **TypeScript tooling**: The tooling around the tests are written in TypeScript and expects to be ran in a Node.js compatible runtime with type-stripping enabled. Never rely on `ts-node`, `node --loader ts-node/esm`, or `--experimental-strip-types`; use only stable, built-in Node.js capabilities.
 - **Implementor Flexibility**: Native code building and loading is delegated to implementors, with the test-suite providing defaults that work for Node.js.
 - **Extra convenience**: Extra (generated) code is provided to make it easier for implementors to load and run tests, such as extra package exports exposing test functions that implementors can integrate with their preferred test frameworks.

--- a/tests/harness/features.js
+++ b/tests/harness/features.js
@@ -1,5 +1,3 @@
-'use strict';
-
 assert.ok(
   typeof experimentalFeatures === 'object' && experimentalFeatures !== null,
   'Expected a global experimentalFeatures object',

--- a/tests/harness/load-addon.js
+++ b/tests/harness/load-addon.js
@@ -1,5 +1,3 @@
-'use strict';
-
 if (typeof loadAddon !== 'function') {
   throw new Error('Expected a global loadAddon function');
 }

--- a/tests/harness/napi-version.js
+++ b/tests/harness/napi-version.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // napiVersion is a positive integer
 if (typeof napiVersion !== 'number' || napiVersion < 1 || !Number.isInteger(napiVersion)) {
   throw new Error('Expected a global napiVersion that is a positive integer');

--- a/tests/harness/skip-test.js
+++ b/tests/harness/skip-test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // skipTest is a function
 if (typeof skipTest !== 'function') {
   throw new Error('Expected a global skipTest function');

--- a/tests/js-native-api/3_callbacks/test.js
+++ b/tests/js-native-api/3_callbacks/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const addon = loadAddon('3_callbacks');
 
 addon.RunCallback(mustCall((msg) => {

--- a/tests/js-native-api/4_object_factory/test.js
+++ b/tests/js-native-api/4_object_factory/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const addon = loadAddon('4_object_factory');
 
 const obj1 = addon('hello');

--- a/tests/js-native-api/5_function_factory/test.js
+++ b/tests/js-native-api/5_function_factory/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const addon = loadAddon('5_function_factory');
 
 const fn = addon();

--- a/tests/js-native-api/7_factory_wrap/test.js
+++ b/tests/js-native-api/7_factory_wrap/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test = loadAddon('7_factory_wrap');
 
 assert.strictEqual(test.finalizeCount, 0);

--- a/tests/js-native-api/8_passing_wrapped/test.js
+++ b/tests/js-native-api/8_passing_wrapped/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const addon = loadAddon('8_passing_wrapped');
 
 let obj1 = addon.createObject(10);

--- a/tests/js-native-api/test_array/test.js
+++ b/tests/js-native-api/test_array/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_array = loadAddon('test_array');
 
 const array = [

--- a/tests/js-native-api/test_bigint/test.js
+++ b/tests/js-native-api/test_bigint/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const {
   IsLossless,
   TestInt64,

--- a/tests/js-native-api/test_conversions/test.js
+++ b/tests/js-native-api/test_conversions/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test = loadAddon('test_conversions');
 
 const boolExpected = /boolean was expected/;

--- a/tests/js-native-api/test_dataview/test.js
+++ b/tests/js-native-api/test_dataview/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Testing api calls for dataview
 const test_dataview = loadAddon('test_dataview');
 

--- a/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
+++ b/tests/js-native-api/test_dataview/test_sharedarraybuffer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // napi_create_dataview accepts a SharedArrayBuffer-backed buffer only on newer
 // Node.js releases (see implementors/node/features.js).
 if (!runtimeFeatures.dataviewSharedArrayBuffer) {

--- a/tests/js-native-api/test_date/test.js
+++ b/tests/js-native-api/test_date/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_date = loadAddon('test_date');
 
 const dateTypeTestDate = test_date.createDate(1549183351);

--- a/tests/js-native-api/test_error/test.js
+++ b/tests/js-native-api/test_error/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const test_error = loadAddon('test_error');
 const theError = new Error('Some error');
 const theTypeError = new TypeError('Some type error');

--- a/tests/js-native-api/test_finalizer/test.js
+++ b/tests/js-native-api/test_finalizer/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // node_api_post_finalizer and node_api_basic_env are both experimental.
 if (!experimentalFeatures.postFinalizer) {
   skipTest();

--- a/tests/js-native-api/test_finalizer/testFatalFinalize.js
+++ b/tests/js-native-api/test_finalizer/testFatalFinalize.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // A fatal finalizer aborts the process, so it runs in a spawned child
 // (testFatalFinalize_child.mjs) rather than tearing down the test runner.
 // Needs the postFinalizer API and the ability to spawn.

--- a/tests/js-native-api/test_function/test.js
+++ b/tests/js-native-api/test_function/test.js
@@ -1,4 +1,3 @@
-'use strict';
 // Flags: --expose-gc
 
 // Testing api calls for function

--- a/tests/js-native-api/test_handle_scope/test.js
+++ b/tests/js-native-api/test_handle_scope/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const testHandleScope = loadAddon('test_handle_scope');
 
 testHandleScope.NewScope();

--- a/tests/js-native-api/test_new_target/test.js
+++ b/tests/js-native-api/test_new_target/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const binding = loadAddon('test_new_target');
 
 class Class extends binding.BaseClass {

--- a/tests/js-native-api/test_number/test.js
+++ b/tests/js-native-api/test_number/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_number = loadAddon('test_number');
 
 // Testing api calls for number

--- a/tests/js-native-api/test_number/test_null.js
+++ b/tests/js-native-api/test_number/test_null.js
@@ -1,4 +1,3 @@
-'use strict';
 const { testNull } = loadAddon('test_number');
 
 const expectedCreateResult = {

--- a/tests/js-native-api/test_promise/test.js
+++ b/tests/js-native-api/test_promise/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_promise = loadAddon('test_promise');
 
 // A resolution

--- a/tests/js-native-api/test_properties/test.js
+++ b/tests/js-native-api/test_properties/test.js
@@ -1,4 +1,3 @@
-'use strict';
 const readonlyErrorRE =
   /^TypeError: Cannot assign to read only property '.*' of object '#<Object>'$/;
 const getterOnlyErrorRE =

--- a/tests/js-native-api/test_reference/test.js
+++ b/tests/js-native-api/test_reference/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const test_reference = loadAddon('test_reference');
 
 // This test script uses external values with finalizer callbacks

--- a/tests/js-native-api/test_reference/test_finalizer.js
+++ b/tests/js-native-api/test_reference/test_finalizer.js
@@ -1,4 +1,3 @@
-'use strict';
 // Flags: --expose-gc --force-node-api-uncaught-exceptions-policy
 
 const binding = loadAddon('test_finalizer');

--- a/tests/js-native-api/test_reference_double_free/test.js
+++ b/tests/js-native-api/test_reference_double_free/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This test makes no assertions. It tests a fix without which it will crash
 // with a double free.
 

--- a/tests/js-native-api/test_reference_double_free/test_wrap.js
+++ b/tests/js-native-api/test_reference_double_free/test_wrap.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // This test makes no assertions. It tests that calling napi_remove_wrap and
 // napi_delete_reference consecutively doesn't crash the process.
 

--- a/tests/js-native-api/test_sharedarraybuffer/test.js
+++ b/tests/js-native-api/test_sharedarraybuffer/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // SharedArrayBuffer support is an experimental feature.
 if (!experimentalFeatures.sharedArrayBuffer) {
   skipTest();

--- a/tests/js-native-api/test_string/test.js
+++ b/tests/js-native-api/test_string/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Testing api calls for string
 const test_string = loadAddon('test_string');
 // The insufficient buffer test case allocates a buffer of size 4, including

--- a/tests/js-native-api/test_string/test_null.js
+++ b/tests/js-native-api/test_string/test_null.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Test passing NULL to object-related Node-APIs.
 const { testNull } = loadAddon('test_string');
 

--- a/tests/js-native-api/test_string/test_v10.js
+++ b/tests/js-native-api/test_string/test_v10.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Tests for Node-API version >= 10 APIs:
 // node_api_create_external_string_latin1/utf16 and
 // node_api_create_property_key_latin1/utf8/utf16.

--- a/tests/js-native-api/test_symbol/test1.js
+++ b/tests/js-native-api/test_symbol/test1.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_symbol = loadAddon('test_symbol');
 
 const sym = test_symbol.New('test');

--- a/tests/js-native-api/test_symbol/test2.js
+++ b/tests/js-native-api/test_symbol/test2.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_symbol = loadAddon('test_symbol');
 
 const fooSym = test_symbol.New('foo');

--- a/tests/js-native-api/test_symbol/test3.js
+++ b/tests/js-native-api/test_symbol/test3.js
@@ -1,4 +1,3 @@
-'use strict';
 const test_symbol = loadAddon('test_symbol');
 
 assert.notStrictEqual(test_symbol.New(), test_symbol.New());

--- a/tests/js-native-api/test_typedarray/test.js
+++ b/tests/js-native-api/test_typedarray/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Testing api calls for arrays
 const test_typedarray = loadAddon('test_typedarray');
 


### PR DESCRIPTION
Closes #41.

Test files under `tests/` are evaluated as ES modules (`package.json` sets
`"type": "module"`, and the Node implementor spawns each file with
`node --expose-gc --import harness.js <file>`), and ES modules are always
strict, so the directive the ports inherited from the upstream CommonJS
sources has no effect.

The issue listed 21 files. There are 37 now, including the four under
`tests/harness/`, since more ports landed after it was filed. All of them
are covered here.

I also added a sentence to `.github/copilot-instructions.md` under "Pure
ECMAScript tests", so the directive does not come back with the next port,
which was the second half of the issue. Happy to move that into `AGENTS.md`
instead if #13 lands first.

Verified on Windows with MSVC: `npm run addons:build` then `npm run node:test`
gives 46/46 passing, and `npm run lint` is clean.

Claude Opus 5 did the sweep across the files and drafted this text; I reviewed
both.
