### PR TITLE
chore: mark test_reference as ported in PORTING.md

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -66,7 +66,7 @@ Tests covering the engine-specific part of Node-API, defined in `js_native_api.h
 | `test_object`                | Not ported | Hard       |
 | `test_promise`               | Ported ✅  | Easy       |
 | `test_properties`            | Ported ✅  | Easy       |
-| `test_reference`             | Not ported | Medium     |
+| `test_reference`             | Ported ✅  | Medium     |
 | `test_reference_double_free` | Ported ✅  | Easy       |
 | `test_sharedarraybuffer`     | Ported ✅  | Medium     |
 | `test_string`                | Ported ✅  | Medium     |


### PR DESCRIPTION
`test_reference` landed in #47 but its PORTING.md row still says "Not ported".