### PR TITLE
docs: replace copilot-instructions.md with AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for node-api-cts
+# node-api-cts
 
 ## Project Overview
 
@@ -13,6 +13,20 @@ Node-API Conformance Test Suite: A pure ECMAScript test suite for Node-API imple
 - **Process Isolation**: The built-in runner for Node.js, run each test in isolation to prevent crashes from aborting entire test suite.
 
 ## Development Focus
-- Port existing tests from `nodejs/node/test/js-native-api` into `tests/engine/` and `nodejs/node/test/node-api` into `tests/runtime/`, removing dependencies on Node.js runtime APIs while preserving test coverage
+- Port existing tests from `nodejs/node/test/js-native-api` into `tests/js-native-api/` and `nodejs/node/test/node-api` into `tests/node-api/`, removing dependencies on Node.js runtime APIs while preserving test coverage
 - Structure tests for easy integration by external implementors
 - Consider following patterns from [web-platform-tests](https://web-platform-tests.org/) and [WebGPU CTS](https://github.com/gpuweb/cts) projects where applicable.
+
+## Building and Running the Tests
+
+Building the addons needs CMake and a C/C++ toolchain on the `PATH`, alongside Node.js.
+
+```sh
+npm ci
+npm run addons:configure  # cmake -S . -B ./build
+npm run addons:build      # cmake --build ./build
+npm run node:test         # run the suite through the Node.js implementor
+npm run lint              # eslint && tsc
+```
+
+Rebuild the addons after touching any C file. `npm run addons:clean` removes the build directory along with the built `.node` files.


### PR DESCRIPTION
Closes #13.

Moves `.github/copilot-instructions.md` to `AGENTS.md` at the root, per
https://agents.md. Git records it as a rename, so the sentence about
`'use strict'` that #64 added comes along with it. This is the follow-up
I offered there.

Two changes to the content itself.

The porting bullet points at `tests/engine/` and `tests/runtime/`. Those
became `tests/js-native-api/` and `tests/node-api/` before the first test
landed, so an agent following the file today writes into directories the
runner never reads.

I also added a section with the build and test commands. Nothing in the
repository currently records that the addons need CMake and a C/C++
toolchain on the `PATH` before `npm run node:test` can do anything, which
is the first thing anyone new to the repo, human or otherwise, runs into.
The five commands in that block are the ones I ran verbatim, in that
order, on a clean checkout in a Debian container, so the section is
tested rather than recalled. Happy to drop it if you would rather keep
the file to principles only.

Claude Opus 5 drafted this; I reviewed it.
