### PR TITLE
fix: don't turn an omitted assert message into undefined

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
           - 22.x
           - 24.x
           - 25.x
+          - 26.x
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Harden Runner

--- a/implementors/node/assert.js
+++ b/implementors/node/assert.js
@@ -7,16 +7,17 @@ import {
   match,
 } from 'node:assert/strict';
 
-const assert = Object.assign((value, message) => ok(value, message), {
-  ok: (value, message) => ok(value, message),
-  strictEqual: (actual, expected, message) =>
-    strictEqual(actual, expected, message),
-  notStrictEqual: (actual, expected, message) =>
-    notStrictEqual(actual, expected, message),
-  deepStrictEqual: (actual, expected, message) =>
-    deepStrictEqual(actual, expected, message),
-  throws: (fn, error, message) => throws(fn, error, message),
-  match: (string, regex, message) => match(string, regex, message),
+// Forward with rest arguments rather than named parameters: an omitted trailing
+// message has to stay omitted. Node.js 26 reads the message as a variadic tuple,
+// so an explicitly passed `undefined` is a message of the wrong type there and
+// the assertion fails with ERR_INVALID_ARG_TYPE instead of the value comparison.
+const assert = Object.assign((...args) => ok(...args), {
+  ok: (...args) => ok(...args),
+  strictEqual: (...args) => strictEqual(...args),
+  notStrictEqual: (...args) => notStrictEqual(...args),
+  deepStrictEqual: (...args) => deepStrictEqual(...args),
+  throws: (...args) => throws(...args),
+  match: (...args) => match(...args),
 });
 
 Object.assign(globalThis, { assert });

--- a/tests/harness/assert.js
+++ b/tests/harness/assert.js
@@ -105,3 +105,49 @@ if (!threw) throw new Error('assert.match must throw when input is not a string'
 threw = false;
 try { assert.match('hello', 'hello'); } catch { threw = true; }
 if (!threw) throw new Error('assert.match must throw when pattern is not a RegExp');
+
+// The message is optional on every method. A failure without one must still
+// report the comparison, and a failure with one must report that message.
+function failureOf(label, fn) {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+  throw new Error(`${label} was expected to throw`);
+}
+
+const optionalMessage = [
+  ['assert', () => assert(false), (m) => assert(false, m)],
+  ['assert.ok', () => assert.ok(false), (m) => assert.ok(false, m)],
+  ['assert.strictEqual', () => assert.strictEqual(1, 2), (m) => assert.strictEqual(1, 2, m)],
+  ['assert.notStrictEqual', () => assert.notStrictEqual(1, 1), (m) => assert.notStrictEqual(1, 1, m)],
+  [
+    'assert.deepStrictEqual',
+    () => assert.deepStrictEqual({ a: 1 }, { a: 2 }),
+    (m) => assert.deepStrictEqual({ a: 1 }, { a: 2 }, m),
+  ],
+  ['assert.match', () => assert.match('hello', /world/), (m) => assert.match('hello', /world/, m)],
+  ['assert.throws', () => assert.throws(() => {}, /oops/), (m) => assert.throws(() => {}, /oops/, m)],
+];
+
+const customMessage = 'a message the caller chose';
+
+for (const [label, withoutMessage, withMessage] of optionalMessage) {
+  // Only a substring check: the strict assert methods append their own value
+  // comparison to a caller supplied message.
+  const described = failureOf(label, () => withMessage(customMessage));
+  if (!described.message.includes(customMessage)) {
+    throw new Error(
+      `${label} must fail with the message it was given but failed with "${described.message}"`,
+    );
+  }
+
+  const bare = failureOf(label, withoutMessage);
+  if (bare.name !== described.name) {
+    throw new Error(
+      `${label} must fail the same way with and without a message, but without one it failed ` +
+      `with "${bare.name}: ${bare.message}" instead of ${described.name}`,
+    );
+  }
+}


### PR DESCRIPTION
The Node.js implementor's `assert` shim swallows the actual/expected diff on Node.js 26, so a
failing test reports a harness error instead of the conformance gap that caused it.

### What happens

`implementors/node/assert.js` forwards each method through an arrow function with named
parameters:

```js
strictEqual: (actual, expected, message) => strictEqual(actual, expected, message),
```

A caller that omits the message therefore passes an explicit `undefined`. Node.js 26 changed the
internal message parameter into a variadic tuple ([nodejs/node#58849](https://github.com/nodejs/node/pull/58849),
first released in v26.0.0), and there `[undefined]` is a message of the wrong type rather than an
absent one:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "message" argument must be one of type string or function. Received undefined
```

So on v26 `assert.strictEqual(1, 2)` reports that instead of an `AssertionError` carrying `1` and
`2`. `strictEqual`, `notStrictEqual` and `deepStrictEqual` take that path; `ok`, `match` and
`throws` still report normally.

| Node.js | `assert.strictEqual(1, 2)` |
|---|---|
| v24.18.1 | `AssertionError` |
| v25.9.0 | `AssertionError` |
| v26.0.0 | `TypeError [ERR_INVALID_ARG_TYPE]` |
| v26.5.1 | `TypeError [ERR_INVALID_ARG_TYPE]` |

The suite stays green either way, because nothing is wrong until an assertion actually fails. That
is also why it matters: the failure message is what a conformance run is read for, and a runtime
with a genuine Node-API gap would be handed a message about the CTS harness rather than about its
own behavior.

### The change

- `implementors/node/assert.js`: forward with rest arguments, so an omitted argument stays omitted.
- `tests/harness/assert.js`: for all seven entry points, check that a failure with a message
  carries that message, and that a failure without one fails the same way. The existing checks only
  asserted *that* something was thrown, which a `TypeError` satisfies.
- `.github/workflows/test.yml`: add `26.x`.

The matrix entry is in the same commit on purpose. 26.x is the only version where the new check has
any teeth, so without it the test is inert. Happy to split it out if you would rather keep matrix
changes separate, and note that it puts the count at five Node.js versions while
[#37](https://github.com/nodejs/node-api-cts/issues/37) is still open about dropping 20.x. For what
it is worth, 20.x and 25.x are both past end of life now (last releases v20.20.2 and v25.9.0, both
March 2026) while 26.x is Current and was untested.

### Verification

Test suite plus lint, all green:

- Windows, MSVC: v24.14.0, v26.5.1
- Linux, Docker `node:<major>-bookworm`, GCC 12.2: 20 (through `ts-strip.js`, as CI does), 22, 25, 26

Teeth check on the new test, running `tests/harness/assert.js` directly rather than through the
runner: with the fix reverted it fails on v26.5.1 with

```
assert.strictEqual must fail the same way with and without a message, but without one it failed
with "TypeError: The "message" argument must be one of type string or function. Received undefined"
instead of AssertionError
```

and passes on v24.18.1, which is exactly why the matrix entry is needed.

Claude Opus 5 found this, wrote the fix and the test, and drafted this text; I reviewed both.
