### PR TITLE
meta: apply AI contribution guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # node-api-cts
 
+AI use must follow the [Node.js AI Use Policy and Guidelines](https://github.com/nodejs/node/blob/main/doc/contributing/ai-guidelines.md) and [Code of Conduct](https://github.com/nodejs/node/blob/main/CODE_OF_CONDUCT.md).
+
 ## Project Overview
 
 Node-API Conformance Test Suite: A pure ECMAScript test suite for Node-API implementors across different JS engines and runtimes (Node.js, Deno, Bun, React Native, WebAssembly, etc.).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,16 @@ contribute:
 - Documentation improvements
 - Joining the Node-API working group and participating in meetings
 
+## AI Use Policy and Guidelines
+
+Node.js requires contributors to understand and take full responsibility for
+every change they propose. Pull requests containing AI-generated code the
+contributor has not personally understood, tested, and verified will likely be closed
+without review.
+
+Be respectful when using AI in communication. Inappropriate or spamming use of
+AI in communication would fall under moderation enforcement.
+
+See [details on our AI use policy and guidelines](https://github.com/nodejs/node/blob/main/doc/contributing/ai-guidelines.md)
+and [Code of Conduct](https://github.com/nodejs/node/blob/main/CODE_OF_CONDUCT.md)
+for guidance.


### PR DESCRIPTION
Given the nature of the current contribution to this repo, we should apply the same AI contribution guideline as specified in https://github.com/nodejs/node/blob/main/doc/contributing/ai-guidelines.md.